### PR TITLE
Tripple dashes instead of a single dash in the table header

### DIFF
--- a/internal/builtin/content_table.go
+++ b/internal/builtin/content_table.go
@@ -135,7 +135,7 @@ func renderTableContent(headers, values []tableCellTmpl, datactx plugin.MapData)
 	buf.WriteByte('\n')
 	buf.WriteByte('|')
 	for range hstr {
-		buf.WriteString("-")
+		buf.WriteString("---")
 		buf.WriteByte('|')
 	}
 	buf.WriteByte('\n')

--- a/internal/builtin/content_table_test.go
+++ b/internal/builtin/content_table_test.go
@@ -58,7 +58,7 @@ func (s *TableGeneratorTestSuite) TestNilQueryResult() {
 		},
 	})
 	s.Equal(&plugin.Content{
-		Markdown: "|User Name|User Age|\n|-|-|\n",
+		Markdown: "|User Name|User Age|\n|---|---|\n",
 	}, content)
 	s.Nil(diags)
 }
@@ -85,7 +85,7 @@ func (s *TableGeneratorTestSuite) TestEmptyQueryResult() {
 		},
 	})
 	s.Equal(&plugin.Content{
-		Markdown: "|User Name|User Age|\n|-|-|\n",
+		Markdown: "|User Name|User Age|\n|---|---|\n",
 	}, content)
 	s.Nil(diags)
 }
@@ -121,7 +121,7 @@ func (s *TableGeneratorTestSuite) TestBasic() {
 		},
 	})
 	s.Equal(&plugin.Content{
-		Markdown: "|User Name|User Age|\n|-|-|\n|John|42|\n|Jane|43|\n",
+		Markdown: "|User Name|User Age|\n|---|---|\n|John|42|\n|Jane|43|\n",
 	}, content)
 	s.Nil(diags)
 }


### PR DESCRIPTION
## Background

Some Markdown flavours (for example, [Github Markdown](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables#creating-a-table)) require at least three dashes in each column of the header row.

## What was changed
 
- instead of printing one dash `-` between `|`, print three dashes `---`
- the unit tests are adjusted