### PR TITLE
Extend `meta` block with additional fields

### DIFF
--- a/parser/definitions/meta.go
+++ b/parser/definitions/meta.go
@@ -1,9 +1,13 @@
 package definitions
 
 type MetaBlock struct {
-	// XXX: is empty sting enougth or use a proper ptr-nil-if-missing?
-	Author string   `hcl:"author,optional"`
-	Tags   []string `hcl:"tags,optional"`
+	Name        string   `hcl:"name,optional"`
+	Description string   `hcl:"description,optional"`
+	Url         string   `hcl:"url,optional"`
+	License     string   `hcl:"license,optional"`
+	Author      string   `hcl:"author,optional"`
+	Tags        []string `hcl:"tags,optional"`
+	UpdatedAt   string   `hcl:"updated_at,optional"`
 
 	// TODO: ?store def range defRange hcl.Range
 }


### PR DESCRIPTION
Adding more fields to `meta` block. 

[Usage example](https://github.com/blackstork-io/fabric-templates/blob/13ea0a5e80feb991355de708fc025e5bc201bddf/cybersec/cti/mitre-ctid-campaign-report.fabric#L3-L16) in [fabric-templates](https://github.com/blackstork-io/fabric-templates) repo.