### PR TITLE
internal/builtin: add constraints to frontmatter

### DIFF
--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -16,7 +16,7 @@ import (
 type noopPluginCaller struct{}
 
 // CallContent implements evaluation.PluginCaller.
-func (n *noopPluginCaller) CallContent(ctx context.Context, name string, config evaluation.Configuration, invocation evaluation.Invocation, context plugin.MapData) (result *plugin.ContentResult, diag diagnostics.Diag) {
+func (n *noopPluginCaller) CallContent(ctx context.Context, name string, config evaluation.Configuration, invocation evaluation.Invocation, context plugin.MapData, contentID uint32) (result *plugin.ContentResult, diag diagnostics.Diag) {
 	return nil, nil
 }
 

--- a/examples/templates/frontmatter/example.fabric
+++ b/examples/templates/frontmatter/example.fabric
@@ -13,7 +13,7 @@ document "example" {
     content title {
         value = "Sub title 1"
     }
-
+    
     content text {
         value = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor dolore magna."
     }

--- a/internal/builtin/content_frontmatter_test.go
+++ b/internal/builtin/content_frontmatter_test.go
@@ -40,8 +40,14 @@ func (s *FrontMatterGeneratorTestSuite) TestInvalidFormat() {
 		}),
 	})
 	ctx := context.Background()
+	document := plugin.ContentSection{}
 	content, diags := s.schema.ProvideContent(ctx, "frontmatter", &plugin.ProvideContentParams{
 		Args: args,
+		DataContext: plugin.MapData{
+			"document": plugin.MapData{
+				"content": document.AsData(),
+			},
+		},
 	})
 	s.Nil(content)
 	s.Equal(hcl.Diagnostics{{
@@ -57,8 +63,14 @@ func (s *FrontMatterGeneratorTestSuite) TestContentAndQueryResultMissing() {
 		"format":  cty.NullVal(cty.String),
 	})
 	ctx := context.Background()
+	document := plugin.ContentSection{}
 	content, diags := s.schema.ProvideContent(ctx, "frontmatter", &plugin.ProvideContentParams{
 		Args: args,
+		DataContext: plugin.MapData{
+			"document": plugin.MapData{
+				"content": document.AsData(),
+			},
+		},
 	})
 	s.Nil(content)
 	s.Equal(hcl.Diagnostics{{
@@ -74,10 +86,14 @@ func (s *FrontMatterGeneratorTestSuite) TestInvalidQueryResult() {
 		"format":  cty.NullVal(cty.String),
 	})
 	ctx := context.Background()
+	document := plugin.ContentSection{}
 	content, diags := s.schema.ProvideContent(ctx, "frontmatter", &plugin.ProvideContentParams{
 		Args: args,
 		DataContext: plugin.MapData{
 			"query_result": plugin.StringData("invalid_type"),
+			"document": plugin.MapData{
+				"content": document.AsData(),
+			},
 		},
 	})
 	s.Nil(content)
@@ -94,8 +110,14 @@ func (s *FrontMatterGeneratorTestSuite) TestContentAndDataContextNil() {
 		"format":  cty.NullVal(cty.String),
 	})
 	ctx := context.Background()
+	document := plugin.ContentSection{}
 	content, diags := s.schema.ProvideContent(ctx, "frontmatter", &plugin.ProvideContentParams{
 		Args: args,
+		DataContext: plugin.MapData{
+			"document": plugin.MapData{
+				"content": document.AsData(),
+			},
+		},
 	})
 	s.Nil(content)
 	s.Equal(hcl.Diagnostics{{
@@ -123,9 +145,16 @@ func (s *FrontMatterGeneratorTestSuite) TestWithContent() {
 		"format": cty.NullVal(cty.String),
 	})
 	ctx := context.Background()
+	document := plugin.ContentSection{}
 	result, diags := s.schema.ProvideContent(ctx, "frontmatter", &plugin.ProvideContentParams{
 		Args: args,
+		DataContext: plugin.MapData{
+			"document": plugin.MapData{
+				"content": document.AsData(),
+			},
+		},
 	})
+	s.Require().Nil(diags)
 	s.Equal("---\n"+
 		"baz: 1\n"+
 		"foo: bar\n"+
@@ -137,7 +166,6 @@ func (s *FrontMatterGeneratorTestSuite) TestWithContent() {
 		"    - fred\n"+
 		"    - plugh\n"+
 		"---\n", result.Content.Print())
-	s.Nil(diags)
 }
 
 func (s *FrontMatterGeneratorTestSuite) TestWithQueryResult() {
@@ -146,6 +174,7 @@ func (s *FrontMatterGeneratorTestSuite) TestWithQueryResult() {
 		"format":  cty.NullVal(cty.String),
 	})
 	ctx := context.Background()
+	document := plugin.ContentSection{}
 	result, diags := s.schema.ProvideContent(ctx, "frontmatter", &plugin.ProvideContentParams{
 		Args: args,
 		DataContext: plugin.MapData{
@@ -161,6 +190,9 @@ func (s *FrontMatterGeneratorTestSuite) TestWithQueryResult() {
 					plugin.StringData("fred"),
 					plugin.StringData("plugh"),
 				},
+			},
+			"document": plugin.MapData{
+				"content": document.AsData(),
 			},
 		},
 	})
@@ -184,6 +216,7 @@ func (s *FrontMatterGeneratorTestSuite) TestFormatYaml() {
 		"format":  cty.StringVal("yaml"),
 	})
 	ctx := context.Background()
+	document := plugin.ContentSection{}
 	result, diags := s.schema.ProvideContent(ctx, "frontmatter", &plugin.ProvideContentParams{
 		Args: args,
 		DataContext: plugin.MapData{
@@ -199,6 +232,9 @@ func (s *FrontMatterGeneratorTestSuite) TestFormatYaml() {
 					plugin.StringData("fred"),
 					plugin.StringData("plugh"),
 				},
+			},
+			"document": plugin.MapData{
+				"content": document.AsData(),
 			},
 		},
 	})
@@ -222,6 +258,7 @@ func (s *FrontMatterGeneratorTestSuite) TestFormatTOML() {
 		"format":  cty.StringVal("toml"),
 	})
 	ctx := context.Background()
+	document := plugin.ContentSection{}
 	result, diags := s.schema.ProvideContent(ctx, "frontmatter", &plugin.ProvideContentParams{
 		Args: args,
 		DataContext: plugin.MapData{
@@ -237,6 +274,9 @@ func (s *FrontMatterGeneratorTestSuite) TestFormatTOML() {
 					plugin.StringData("fred"),
 					plugin.StringData("plugh"),
 				},
+			},
+			"document": plugin.MapData{
+				"content": document.AsData(),
 			},
 		},
 	})
@@ -258,6 +298,7 @@ func (s *FrontMatterGeneratorTestSuite) TestFormatJSON() {
 		"format":  cty.StringVal("json"),
 	})
 	ctx := context.Background()
+	document := plugin.ContentSection{}
 	result, diags := s.schema.ProvideContent(ctx, "frontmatter", &plugin.ProvideContentParams{
 		Args: args,
 		DataContext: plugin.MapData{
@@ -273,6 +314,9 @@ func (s *FrontMatterGeneratorTestSuite) TestFormatJSON() {
 					plugin.StringData("fred"),
 					plugin.StringData("plugh"),
 				},
+			},
+			"document": plugin.MapData{
+				"content": document.AsData(),
 			},
 		},
 	})

--- a/internal/builtin/content_helpers.go
+++ b/internal/builtin/content_helpers.go
@@ -1,0 +1,77 @@
+package builtin
+
+import "github.com/blackstork-io/fabric/plugin"
+
+func countDeclarations(data *plugin.ContentSection, name string) int {
+	count := 0
+	for _, child := range data.Children {
+		if section, ok := child.(*plugin.ContentSection); ok {
+			count += countDeclarations(section, name)
+			continue
+		}
+		if element, ok := child.(*plugin.ContentElement); ok {
+			meta := element.Meta()
+			if meta != nil && meta.Provider == name {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func parseScope(datactx plugin.MapData) (document *plugin.ContentSection, section *plugin.ContentSection) {
+	documentMap, ok := datactx["document"]
+	if !ok {
+		return
+	}
+
+	contentMap, ok := documentMap.(plugin.MapData)["content"]
+	if !ok {
+		return
+	}
+
+	content, err := plugin.ParseContentData(contentMap.(plugin.MapData))
+	if err != nil {
+		return
+	}
+
+	document, ok = content.(*plugin.ContentSection)
+	if !ok {
+		return
+	}
+
+	sectionMap, ok := datactx["section"]
+	if !ok || sectionMap == nil {
+		return
+	}
+	contentMap, ok = sectionMap.(plugin.MapData)["content"]
+	if !ok {
+		return
+	}
+	content, err = plugin.ParseContentData(contentMap.(plugin.MapData))
+	if err != nil {
+		return
+	}
+	section, ok = content.(*plugin.ContentSection)
+	if !ok {
+		return
+	}
+	return document, section
+}
+
+func findDepth(parent *plugin.ContentSection, id uint32, depth int) int {
+	if parent.ID() == id {
+		return depth
+	}
+	for _, child := range parent.Children {
+		if child.ID() == id {
+			return depth
+		}
+		if child, ok := child.(*plugin.ContentSection); ok {
+			if d := findDepth(child, id, depth+1); d > -1 {
+				return d
+			}
+		}
+	}
+	return -1
+}

--- a/internal/builtin/content_title.go
+++ b/internal/builtin/content_title.go
@@ -91,63 +91,6 @@ func genTitleContent(ctx context.Context, params *plugin.ProvideContentParams) (
 	}, nil
 }
 
-func parseScope(datactx plugin.MapData) (document *plugin.ContentSection, section *plugin.ContentSection) {
-	documentMap, ok := datactx["document"]
-	if !ok {
-		return
-	}
-
-	contentMap, ok := documentMap.(plugin.MapData)["content"]
-	if !ok {
-		return
-	}
-
-	content, err := plugin.ParseContentData(contentMap.(plugin.MapData))
-	if err != nil {
-		return
-	}
-
-	document, ok = content.(*plugin.ContentSection)
-	if !ok {
-		return
-	}
-
-	sectionMap, ok := datactx["section"]
-	if !ok || sectionMap == nil {
-		return
-	}
-	contentMap, ok = sectionMap.(plugin.MapData)["content"]
-	if !ok {
-		return
-	}
-	content, err = plugin.ParseContentData(contentMap.(plugin.MapData))
-	if err != nil {
-		return
-	}
-	section, ok = content.(*plugin.ContentSection)
-	if !ok {
-		return
-	}
-	return document, section
-}
-
-func findDepth(parent *plugin.ContentSection, id uint32, depth int) int {
-	if parent.ID() == id {
-		return depth
-	}
-	for _, child := range parent.Children {
-		if child.ID() == id {
-			return depth
-		}
-		if child, ok := child.(*plugin.ContentSection); ok {
-			if d := findDepth(child, id, depth+1); d > -1 {
-				return d
-			}
-		}
-	}
-	return -1
-}
-
 func findDefaultTitleSize(datactx plugin.MapData) int64 {
 	document, section := parseScope(datactx)
 	if section == nil {

--- a/parser/caller.go
+++ b/parser/caller.go
@@ -66,7 +66,7 @@ func (c *Caller) pluginData(kind, name string) (pluginData, diagnostics.Diag) {
 	}
 }
 
-func (c *Caller) callPlugin(ctx context.Context, kind, name string, config evaluation.Configuration, invocation evaluation.Invocation, dataCtx plugin.MapData) (res any, diags diagnostics.Diag) {
+func (c *Caller) callPlugin(ctx context.Context, kind, name string, config evaluation.Configuration, invocation evaluation.Invocation, dataCtx plugin.MapData, contentID uint32) (res any, diags diagnostics.Diag) {
 	data, diags := c.pluginData(kind, name)
 	if diags.HasErrors() {
 		return
@@ -146,6 +146,7 @@ func (c *Caller) callPlugin(ctx context.Context, kind, name string, config evalu
 			Config:      configVal,
 			Args:        pluginArgs,
 			DataContext: dataCtx,
+			ContentID:   contentID,
 		})
 		res = content
 		diags.ExtendHcl(diag)
@@ -153,10 +154,10 @@ func (c *Caller) callPlugin(ctx context.Context, kind, name string, config evalu
 	return
 }
 
-func (c *Caller) CallContent(ctx context.Context, name string, config evaluation.Configuration, invocation evaluation.Invocation, dataCtx plugin.MapData) (result *plugin.ContentResult, diag diagnostics.Diag) {
+func (c *Caller) CallContent(ctx context.Context, name string, config evaluation.Configuration, invocation evaluation.Invocation, dataCtx plugin.MapData, contentID uint32) (result *plugin.ContentResult, diag diagnostics.Diag) {
 	var ok bool
 	var res any
-	res, diag = c.callPlugin(ctx, definitions.BlockKindContent, name, config, invocation, dataCtx)
+	res, diag = c.callPlugin(ctx, definitions.BlockKindContent, name, config, invocation, dataCtx, contentID)
 	if diag.HasErrors() {
 		return
 	}
@@ -179,7 +180,7 @@ func (c *Caller) ContentInvocationOrder(ctx context.Context, name string) (order
 func (c *Caller) CallData(ctx context.Context, name string, config evaluation.Configuration, invocation evaluation.Invocation) (result plugin.Data, diag diagnostics.Diag) {
 	var ok bool
 	var res any
-	res, diag = c.callPlugin(ctx, definitions.BlockKindData, name, config, invocation, nil)
+	res, diag = c.callPlugin(ctx, definitions.BlockKindData, name, config, invocation, nil, 0)
 	if diag.HasErrors() {
 		return
 	}

--- a/parser/definitions/parsed_plugin.go
+++ b/parser/definitions/parsed_plugin.go
@@ -55,7 +55,7 @@ func (c *ParsedContent) Render(ctx context.Context, caller evaluation.ContentCal
 		return
 	}
 
-	resultStr, diag := caller.CallContent(ctx, c.PluginName, c.Config, c.Invocation, dataCtx.AsJQData().(plugin.MapData))
+	resultStr, diag := caller.CallContent(ctx, c.PluginName, c.Config, c.Invocation, dataCtx.AsJQData().(plugin.MapData), contentID)
 	if diags.Extend(diag) || resultStr == nil {
 		// XXX: What to do if we have errors while executing content blocks?
 		// just skipping the value for now...

--- a/parser/evaluation/plugincaller.go
+++ b/parser/evaluation/plugincaller.go
@@ -12,7 +12,7 @@ type DataCaller interface {
 }
 
 type ContentCaller interface {
-	CallContent(ctx context.Context, name string, config Configuration, invocation Invocation, context plugin.MapData) (result *plugin.ContentResult, diag diagnostics.Diag)
+	CallContent(ctx context.Context, name string, config Configuration, invocation Invocation, context plugin.MapData, contentID uint32) (result *plugin.ContentResult, diag diagnostics.Diag)
 	ContentInvocationOrder(ctx context.Context, name string) (order plugin.InvocationOrder, diag diagnostics.Diag)
 }
 


### PR DESCRIPTION
Adding constraints for `frontmatter` to be declared only once and only at the top-level of the document.

Related issue: 
- #116 