### PR TITLE
Simple dockerfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,13 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: stable
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          # TODO: setup creds
+          username: "${{ secrets.DOCKERHUB_USERNAME }}"
+          password: "${{ secrets.DOCKERHUB_TOKEN }}"
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
@@ -28,3 +35,5 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # TODO: setup user/repo
+          CONTAINER_REPO_NAME: "blackstork-io/fabric"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: stable
-      -
-        name: Login to Docker Hub
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           # TODO: setup creds
@@ -35,5 +34,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # TODO: setup user/repo
-          CONTAINER_REPO_NAME: "blackstork-io/fabric"
+          CONTAINER_REPO_NAME: "blackstorkio/fabric"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,10 +23,16 @@ builds:
       - -X github.com/blackstork-io/fabric/cmd.version={{.Version}}
       - -X github.com/blackstork-io/fabric/cmd.builtBy=goreleaser
 
-    goos:
-      - linux
-      - windows
-      - darwin
+    targets:
+      - linux_amd64_v1
+      - linux_arm64 # implicitly v8
+      - linux_386
+      - darwin_amd64_v1
+      - darwin_arm64
+      - windows_amd64_v1
+      - windows_arm64_8
+      - windows_386
+
 
   # Plugins
   # TODO: generate this list with custom script or use Premium goreleaser to template it
@@ -361,6 +367,49 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
+
+dockers:
+  - use: buildx
+    goos: linux
+    goarch: amd64
+    goamd64: v1
+    ids:
+      - fabric
+    image_templates:
+      - "{{ .Env.CONTAINER_REPO_NAME }}:platform-specific-{{ .Version }}-amd64v1"
+    build_flag_templates:
+      - "--platform=linux/amd64/v1"
+  - use: buildx
+    goos: linux
+    goarch: arm64
+    ids:
+      - fabric
+    image_templates:
+      - "{{ .Env.CONTAINER_REPO_NAME }}:platform-specific-{{ .Version }}-arm64v8"
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+  - use: buildx
+    goos: linux
+    goarch: "386"
+    ids:
+      - fabric
+    image_templates:
+      - "{{ .Env.CONTAINER_REPO_NAME }}:platform-specific-{{ .Version }}-386"
+    build_flag_templates:
+      - "--platform=linux/386"
+
+docker_manifests:
+  - name_template: "{{ .Env.CONTAINER_REPO_NAME }}:{{ .Version }}"
+    image_templates:
+    - "{{ .Env.CONTAINER_REPO_NAME }}:platform-specific-{{ .Version }}-amd64v1"
+    - "{{ .Env.CONTAINER_REPO_NAME }}:platform-specific-{{ .Version }}-arm64v8"
+    - "{{ .Env.CONTAINER_REPO_NAME }}:platform-specific-{{ .Version }}-386"
+  - name_template: "{{ .Env.CONTAINER_REPO_NAME }}:latest"
+    image_templates:
+    - "{{ .Env.CONTAINER_REPO_NAME }}:platform-specific-{{ .Version }}-amd64v1"
+    - "{{ .Env.CONTAINER_REPO_NAME }}:platform-specific-{{ .Version }}-arm64v8"
+    - "{{ .Env.CONTAINER_REPO_NAME }}:platform-specific-{{ .Version }}-386"
+
 
 changelog:
   sort: asc

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -376,7 +376,7 @@ dockers:
     ids:
       - fabric
     image_templates:
-      - "{{ .Env.CONTAINER_REPO_NAME }}:platform-specific-{{ .Version }}-amd64v1"
+      - "{{ .Env.CONTAINER_REPO_NAME }}:latest-amd64v1"
     build_flag_templates:
       - "--platform=linux/amd64/v1"
   - use: buildx
@@ -385,7 +385,7 @@ dockers:
     ids:
       - fabric
     image_templates:
-      - "{{ .Env.CONTAINER_REPO_NAME }}:platform-specific-{{ .Version }}-arm64v8"
+      - "{{ .Env.CONTAINER_REPO_NAME }}:latest-arm64v8"
     build_flag_templates:
       - "--platform=linux/arm64/v8"
   - use: buildx
@@ -394,21 +394,21 @@ dockers:
     ids:
       - fabric
     image_templates:
-      - "{{ .Env.CONTAINER_REPO_NAME }}:platform-specific-{{ .Version }}-386"
+      - "{{ .Env.CONTAINER_REPO_NAME }}:latest-386"
     build_flag_templates:
       - "--platform=linux/386"
 
 docker_manifests:
   - name_template: "{{ .Env.CONTAINER_REPO_NAME }}:{{ .Version }}"
     image_templates:
-    - "{{ .Env.CONTAINER_REPO_NAME }}:platform-specific-{{ .Version }}-amd64v1"
-    - "{{ .Env.CONTAINER_REPO_NAME }}:platform-specific-{{ .Version }}-arm64v8"
-    - "{{ .Env.CONTAINER_REPO_NAME }}:platform-specific-{{ .Version }}-386"
+    - "{{ .Env.CONTAINER_REPO_NAME }}:latest-amd64v1"
+    - "{{ .Env.CONTAINER_REPO_NAME }}:latest-arm64v8"
+    - "{{ .Env.CONTAINER_REPO_NAME }}:latest-386"
   - name_template: "{{ .Env.CONTAINER_REPO_NAME }}:latest"
     image_templates:
-    - "{{ .Env.CONTAINER_REPO_NAME }}:platform-specific-{{ .Version }}-amd64v1"
-    - "{{ .Env.CONTAINER_REPO_NAME }}:platform-specific-{{ .Version }}-arm64v8"
-    - "{{ .Env.CONTAINER_REPO_NAME }}:platform-specific-{{ .Version }}-386"
+    - "{{ .Env.CONTAINER_REPO_NAME }}:latest-amd64v1"
+    - "{{ .Env.CONTAINER_REPO_NAME }}:latest-arm64v8"
+    - "{{ .Env.CONTAINER_REPO_NAME }}:latest-386"
 
 
 changelog:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM alpine:3.19 as downloader
-ADD https://github.com/blackstork-io/fabric/releases/latest/download/fabric_linux_x86_64.tar.gz /
-RUN tar -xf fabric_linux_x86_64.tar.gz
-
-
-FROM gcr.io/distroless/static-debian12:latest
-COPY --from=downloader /fabric /fabric
+FROM scratch
 ENTRYPOINT [ "/fabric" ]
 CMD [ "--help" ]
+COPY fabric /fabric

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM scratch
+FROM alpine:3.19
 ENTRYPOINT [ "/fabric" ]
 CMD [ "--help" ]
 COPY fabric /fabric

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# syntax=docker/dockerfile:1
+
+FROM alpine:3.19 as downloader
+ADD https://github.com/blackstork-io/fabric/releases/latest/download/fabric_linux_x86_64.tar.gz /
+RUN tar -xf fabric_linux_x86_64.tar.gz
+
+
+FROM gcr.io/distroless/static-debian12:latest
+COPY --from=downloader /fabric /fabric
+ENTRYPOINT [ "/fabric" ]
+CMD [ "--help" ]


### PR DESCRIPTION
I started working on a full dockerization of the project, but goreleaser was throwing some strange errors like
```
11.69 go: github.com/blackstork-io/fabric imports
11.69   github.com/blackstork-io/fabric/cmd: no matching versions for query "latest"
```

And I thought that since we already have the built artifacts - why not just reuse them? Here's a simple dockerfile that just downloads the latest release from github. Is this enough, or should it build the binary from scratch?
