### PR TITLE
Render `src` and `alt` values as templates in `content.image`

### DIFF
--- a/internal/builtin/content_image.go
+++ b/internal/builtin/content_image.go
@@ -1,10 +1,13 @@
 package builtin
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"strings"
+	"text/template"
 
+	"github.com/Masterminds/sprig/v3"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
 
@@ -30,7 +33,7 @@ func makeImageContentProvider() *plugin.ContentProvider {
 				// Not using empty string as DefaultVal here for semantical meaning
 			},
 		},
-		Doc: "Inserts an image",
+		Doc: "Returns an image tag",
 	}
 }
 
@@ -47,11 +50,51 @@ func genImageContent(ctx context.Context, params *plugin.ProvideContentParams) (
 	if alt.IsNull() {
 		alt = cty.StringVal("")
 	}
-	srcStr := strings.TrimSpace(strings.ReplaceAll(src.AsString(), "\n", ""))
-	altStr := strings.TrimSpace(strings.ReplaceAll(alt.AsString(), "\n", ""))
+
+	srcStr, err := renderAsTemplate("src", src.AsString(), params.DataContext)
+	if err != nil {
+		return nil, hcl.Diagnostics{{
+			Severity: hcl.DiagError,
+			Summary:  "Failed to render src value as a template",
+			Detail:   err.Error(),
+		}}
+	}
+
+	altStr, err := renderAsTemplate("alt", alt.AsString(), params.DataContext)
+	if err != nil {
+		return nil, hcl.Diagnostics{{
+			Severity: hcl.DiagError,
+			Summary:  "Failed to render alt value as a template",
+			Detail:   err.Error(),
+		}}
+	}
+
+	// Make sure there are no line breaks in the values
+	srcStr = strings.TrimSpace(strings.ReplaceAll(srcStr, "\n", ""))
+	altStr = strings.TrimSpace(strings.ReplaceAll(altStr, "\n", ""))
 	return &plugin.ContentResult{
 		Content: &plugin.ContentElement{
 			Markdown: fmt.Sprintf("![%s](%s)", altStr, srcStr),
 		},
 	}, nil
+}
+
+func renderAsTemplate(name string, value string, datactx plugin.MapData) (string, error) {
+
+	if value == "" {
+		return "", nil
+	}
+
+	tmpl, err := template.New(name).Funcs(sprig.FuncMap()).Parse(value)
+
+	if err != nil {
+		return "", fmt.Errorf("failed to parse text template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, datactx.Any())
+	if err != nil {
+		return "", fmt.Errorf("failed to execute text template: %w", err)
+	}
+	return strings.TrimSpace(buf.String()), nil
 }

--- a/justfile
+++ b/justfile
@@ -20,6 +20,9 @@ lint: format
 test:
     go test -timeout 10s -race -short -v ./...
 
+test-pretty:
+    gotestsum --format dots-v2 -- -timeout 10s -race -short -v ./...
+
 test-all:
     go test -timeout 5m -race -v ./...
 


### PR DESCRIPTION
## What was changed
- `src` and `alt` values in `content.image` block are treated as Go templates
- the unit tests were updated

Fixes https://github.com/blackstork-io/fabric/issues/163