### PR TITLE
Simplify `content.openai_text` prompt rendering

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -228,13 +228,16 @@ document "greeting" {
 
   content openai_text {
     query = "{planet: .data.inline.solar_system.planets[-1]}"
-    prompt = "Share a fact about the planet specified in the provided data"
+    prompt = <<-EOT
+      Share a fact about the planet specified in the provided
+      data: {{ .query_result | toRawJson }}
+    EOT
   }
 
 }
 ```
 
-A JQ query `"{planet: .data.inline.solar_system.planets[-1]}` in `query` argument fetches the last item from the list (`Neptune`) and creates a new JSON object `{"planet": "Neptune"}`. This object is stored under `query_result` field in the context. `openai_text` content provider combines the `prompt` string with the `query_result` value to create a user prompt for OpenAI API.
+A JQ query `"{planet: .data.inline.solar_system.planets[-1]}` in `query` argument fetches the last item from the list (`Neptune`) and creates a new JSON object `{"planet": "Neptune"}`, stored under `query_result` field in the context.
 
 {{< hint note >}}
 If you would like to specify a system prompt for OpenAI API, you can set it up in the configuration for `openai_text` provider. See the provider's [documentation]({{< ref "plugins/openai/content-providers/openai_text" >}}) for more configuration options.
@@ -279,7 +282,10 @@ document "greeting" {
 
   content openai_text {
     query = "{planet: .data.inline.solar_system.planets[-1]}"
-    prompt = "Share a fact about the planet specified in the provided data"
+    prompt = <<-EOT
+      Share a fact about the planet specified in the provided
+      data: {{ .query_result | toRawJson }}
+    EOT
   }
 
 }

--- a/internal/openai/content_openai_text.go
+++ b/internal/openai/content_openai_text.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"text/template"
 	"strings"
+	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/hashicorp/hcl/v2"

--- a/internal/openai/content_openai_text.go
+++ b/internal/openai/content_openai_text.go
@@ -3,10 +3,9 @@ package openai
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"html/template"
+	"text/template"
 	"strings"
 
 	"github.com/Masterminds/sprig/v3"
@@ -102,15 +101,6 @@ func renderText(ctx context.Context, cli client.Client, cfg, args cty.Value, dat
 	content, err := templateText(content, datactx)
 	if err != nil {
 		return "", err
-	}
-	if datactx != nil {
-		if queryResult, ok := datactx[queryResultKey]; ok {
-			data, err := json.MarshalIndent(queryResult, "", "  ")
-			if err != nil {
-				return "", err
-			}
-			content += "\n```\n" + string(data) + "\n```"
-		}
 	}
 	params.Messages = append(params.Messages, client.ChatCompletionMessage{
 		Role:    "user",

--- a/internal/openai/content_openai_text_test.go
+++ b/internal/openai/content_openai_text_test.go
@@ -93,7 +93,7 @@ func (s *OpenAITextContentTestSuite) TestAdvanced() {
 			},
 			{
 				Role:    "user",
-				Content: "Tell me a story about BAR.\n```\n{\n  \"foo\": \"bar\"\n}\n```",
+				Content: "Tell me a story about BAR. {\"foo\":\"bar\"}",
 			},
 		},
 	}).Return(&client.ChatCompletionResult{
@@ -111,7 +111,7 @@ func (s *OpenAITextContentTestSuite) TestAdvanced() {
 	ctx := context.Background()
 	result, diags := s.schema.ContentFunc(ctx, &plugin.ProvideContentParams{
 		Args: cty.ObjectVal(map[string]cty.Value{
-			"prompt": cty.StringVal("Tell me a story about {{.query_result.foo | upper}}."),
+			"prompt": cty.StringVal("Tell me a story about {{.query_result.foo | upper}}. {{ .query_result | toRawJson }}"),
 			"model":  cty.StringVal("model_123"),
 		}),
 		Config: cty.ObjectVal(map[string]cty.Value{


### PR DESCRIPTION
## What was changed
- dropped the logic that was appending serialized query result to the prompt
- switched to `text/template` instead of `html/template` to avoid unnecessary HTML-specific escaping in the prompt
- the unit tests were updated

Fixes https://github.com/blackstork-io/fabric/issues/170