### PR TITLE
Adjust `txt`, `csv` and `json` data sources to use the same exec attributes

### DIFF
--- a/docs/plugins/builtin/content-providers/image.md
+++ b/docs/plugins/builtin/content-providers/image.md
@@ -2,7 +2,7 @@
 title: image
 plugin:
   name: blackstork/builtin
-  description: "Inserts an image"
+  description: "Returns an image tag"
   tags: []
   version: "v0.4.1"
   source_github: "https://github.com/blackstork-io/fabric/tree/main/internal/builtin/"
@@ -16,7 +16,7 @@ type: docs
 {{< plugin-resource-header "blackstork/builtin" "builtin" "v0.4.1" "image" "content provider" >}}
 
 ## Description
-Inserts an image
+Returns an image tag
 
 The content provider is built-in, which means it's a part of `fabric` binary. It's available out-of-the-box, no installation required.
 

--- a/docs/plugins/builtin/data-sources/csv.md
+++ b/docs/plugins/builtin/data-sources/csv.md
@@ -2,7 +2,7 @@
 title: csv
 plugin:
   name: blackstork/builtin
-  description: "Imports and parses a csv file"
+  description: "Loads CSV files with the names that match a provided \"glob\" pattern or a single file from a provided path"
   tags: []
   version: "v0.4.1"
   source_github: "https://github.com/blackstork-io/fabric/tree/main/internal/builtin/"
@@ -16,22 +16,44 @@ type: docs
 {{< plugin-resource-header "blackstork/builtin" "builtin" "v0.4.1" "csv" "data source" >}}
 
 ## Description
-Imports and parses a csv file.
+Loads CSV files with the names that match a provided "glob" pattern or a single file from a provided path.
 
-We assume the table has a header and turn each line into a map based on the header titles.
+Either "glob" or "path" attribute must be set.
 
-For example following table
+When "path" attribute is specified, only the content of the file is returned. For example, the following CSV data:
 
 | column_A | column_B | column_C |
 | -------- | -------- | -------- |
-| Test     | true     | 42       |
-| Line 2   | false    | 4.2      |
+| Foo      | true     | 42       |
+| Bar      | false    | 4.2      |
 
-will be represented as the following structure:
 ```json
 [
-  {"column_A": "Test", "column_B": true, "column_C": 42},
-  {"column_A": "Line 2", "column_B": false, "column_C": 4.2}
+  {"column_A": "Foo", "column_B": true, "column_C": 42},
+  {"column_A": "Bar", "column_B": false, "column_C": 4.2}
+]
+```
+
+When "glob" attribute is specified, the structure returned by the data source is a list of dicts that contain the content of the file and file metadata. For example:
+
+```json
+[
+  {
+    "file_path": "path/file-a.csv",
+    "file_name": "file-a.csv",
+    "content": [
+      {"column_A": "Foo", "column_B": true, "column_C": 42},
+      {"column_A": "Bar", "column_B": false, "column_C": 4.2}
+    ]
+  },
+  {
+    "file_path": "path/file-b.csv",
+    "file_name": "file-b.csv",
+    "content": [
+      {"column_C": "Baz", "column_D": 1},
+      {"column_C": "Clu", "column_D": 2}
+    ]
+  },
 ]
 ```
 
@@ -56,7 +78,20 @@ The data source supports the following parameters in the data blocks:
 
 ```hcl
 data csv {
-  # Required string. For example:
-  path = "path/to/file.csv"
+  # A glob pattern to select CSV files for reading
+  #
+  # For example:
+  # glob = "path/to/files*.csv"
+  #
+  # Optional string. Default value:
+  glob = null
+
+  # A file path to a CSV file to read
+  #
+  # For example:
+  # path = "path/table.csv"
+  #
+  # Optional string. Default value:
+  path = null
 }
 ```

--- a/docs/plugins/builtin/data-sources/json.md
+++ b/docs/plugins/builtin/data-sources/json.md
@@ -2,7 +2,7 @@
 title: json
 plugin:
   name: blackstork/builtin
-  description: "Imports and parses the files matching \"glob\""
+  description: "Loads JSON files with the names that match a provided \"glob\" pattern or a single file from a provided path"
   tags: []
   version: "v0.4.1"
   source_github: "https://github.com/blackstork-io/fabric/tree/main/internal/builtin/"
@@ -16,23 +16,32 @@ type: docs
 {{< plugin-resource-header "blackstork/builtin" "builtin" "v0.4.1" "json" "data source" >}}
 
 ## Description
-Imports and parses the files matching "glob".
-Results are presented using the following structure:
+Loads JSON files with the names that match a provided "glob" pattern or a single file from a provided path.
+
+Either "glob" or "path" attribute must be provided.
+
+When "path" is specified, only the content of the file is returned.
+When "glob" is specified, the structure returned by the data source is a list of dicts that contain the content of the file and file metadata.
+
+For example, with "glob" set, the data source will return the following data structure:
+
 ```json
-  [
-    {
-      "filename": "<name of the file matched by glob>",
-      "contents": {
-        "contents of the file": "parsed as json"
-      },
+[
+  {
+    "file_path": "path/file-a.json",
+    "file_name": "file-a.json",
+    "content": {
+      "foo": "bar"
     },
-    {
-      "filename": "<next file>",
-      "contents": {
-        "next": "contents"
-      },
-    }
-  ]
+  },
+  {
+    "file_path": "path/file-b.json",
+    "file_name": "file-b.json",
+    "content": [
+      {"x": "y"}
+    ],
+  }
+]
 ```
 
 The data source is built-in, which means it's a part of `fabric` binary. It's available out-of-the-box, no installation required.
@@ -47,9 +56,20 @@ The data source supports the following parameters in the data blocks:
 
 ```hcl
 data json {
-  # A pattern that selects the json files to be read
+  # A glob pattern to select JSON files for reading
   #
-  # Required string. For example:
-  glob = "reports/*_data.json"
+  # For example:
+  # glob = "data/*_alerts.json"
+  #
+  # Optional string. Default value:
+  glob = null
+
+  # A file path to a JSON file to read
+  #
+  # For example:
+  # path = "data/alerts.json"
+  #
+  # Optional string. Default value:
+  path = null
 }
 ```

--- a/docs/plugins/builtin/data-sources/txt.md
+++ b/docs/plugins/builtin/data-sources/txt.md
@@ -2,7 +2,7 @@
 title: txt
 plugin:
   name: blackstork/builtin
-  description: "Reads the file at \"path\" into a string"
+  description: "Loads TXT files with the names that match a provided \"glob\" pattern or a single file from a provided path"
   tags: []
   version: "v0.4.1"
   source_github: "https://github.com/blackstork-io/fabric/tree/main/internal/builtin/"
@@ -16,7 +16,27 @@ type: docs
 {{< plugin-resource-header "blackstork/builtin" "builtin" "v0.4.1" "txt" "data source" >}}
 
 ## Description
-Reads the file at "path" into a string
+Loads TXT files with the names that match a provided "glob" pattern or a single file from a provided path.
+
+Either "glob" or "path" attribute must be set.
+
+When "path" is specified, only the content of the file is returned.
+When "glob" attribute is specified, the structure returned by the data source is a list of dicts that contain the content of the file and file metadata. For example:
+
+```json
+[
+  {
+    "file_path": "path/file-a.txt",
+    "file_name": "file-a.txt",
+    "content": "foobar"
+  },
+  {
+    "file_path": "path/file-b.txt",
+    "file_name": "file-b.txt",
+    "content": "x\\ny\\nz"
+  }
+]
+```
 
 The data source is built-in, which means it's a part of `fabric` binary. It's available out-of-the-box, no installation required.
 
@@ -30,7 +50,20 @@ The data source supports the following parameters in the data blocks:
 
 ```hcl
 data txt {
-  # Required string. For example:
-  path = "path/to/file.txt"
+  # A glob pattern to select TXT files for reading
+  #
+  # For example:
+  # glob = "path/to/files*.txt"
+  #
+  # Optional string. Default value:
+  glob = null
+
+  # A file path to a TXT file to read
+  #
+  # For example:
+  # path = "data/disclaimer.txt"
+  #
+  # Optional string. Default value:
+  path = null
 }
 ```

--- a/docs/plugins/plugins.json
+++ b/docs/plugins/plugins.json
@@ -26,6 +26,7 @@
           "delimiter"
         ],
         "arguments": [
+          "glob",
           "path"
         ]
       },
@@ -53,7 +54,8 @@
         "name": "json",
         "type": "data-source",
         "arguments": [
-          "glob"
+          "glob",
+          "path"
         ]
       },
       {
@@ -118,6 +120,7 @@
         "name": "txt",
         "type": "data-source",
         "arguments": [
+          "glob",
           "path"
         ]
       }

--- a/internal/builtin/data_csv_test.go
+++ b/internal/builtin/data_csv_test.go
@@ -3,6 +3,8 @@ package builtin
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
@@ -23,18 +25,21 @@ func Test_makeCSVDataSchema(t *testing.T) {
 }
 
 func Test_fetchCSVData(t *testing.T) {
+	slog.SetLogLoggerLevel(slog.LevelDebug)
+
 	tt := []struct {
 		name          string
 		path          string
+		glob          string
 		delimiter     string
-		expectedRes   plugin.Data
+		expectedData  plugin.Data
 		expectedDiags [][]testtools.Assert
 	}{
 		{
-			name:      "comma_delim",
+			name:      "comma_delim_path",
 			path:      "testdata/csv/comma.csv",
 			delimiter: ",",
-			expectedRes: plugin.ListData{
+			expectedData: plugin.ListData{
 				plugin.MapData{
 					"id":     plugin.StringData("b8fa4bb0-6dd4-45ba-96e0-9a182b2b932e"),
 					"active": plugin.BoolData(true),
@@ -59,10 +64,10 @@ func Test_fetchCSVData(t *testing.T) {
 			},
 		},
 		{
-			name:      "semicolon_delim",
+			name:      "semicolon_delim_path",
 			path:      "testdata/csv/semicolon.csv",
 			delimiter: ";",
-			expectedRes: plugin.ListData{
+			expectedData: plugin.ListData{
 				plugin.MapData{
 					"id":     plugin.StringData("b8fa4bb0-6dd4-45ba-96e0-9a182b2b932e"),
 					"active": plugin.BoolData(true),
@@ -87,10 +92,45 @@ func Test_fetchCSVData(t *testing.T) {
 			},
 		},
 		{
-			name: "empty_path",
+			name:      "comma_delim_glob",
+			glob:      "testdata/csv/comm*.csv",
+			delimiter: ",",
+			expectedData: plugin.ListData{
+				plugin.MapData{
+					"file_name": plugin.StringData("comma.csv"),
+					"file_path": plugin.StringData("testdata/csv/comma.csv"),
+					"content": plugin.ListData{
+						plugin.MapData{
+							"id":     plugin.StringData("b8fa4bb0-6dd4-45ba-96e0-9a182b2b932e"),
+							"active": plugin.BoolData(true),
+							"name":   plugin.StringData("Stacey"),
+							"age":    plugin.NumberData(26),
+							"height": plugin.NumberData(1.98),
+						},
+						plugin.MapData{
+							"id":     plugin.StringData("b0086c49-bcd8-4aae-9f88-4f46b128e709"),
+							"active": plugin.BoolData(false),
+							"name":   plugin.StringData("Myriam"),
+							"age":    plugin.NumberData(33),
+							"height": plugin.NumberData(1.81),
+						},
+						plugin.MapData{
+							"id":     plugin.StringData("a12d2a8c-eebc-42b3-be52-1ab0a2969a81"),
+							"active": plugin.BoolData(true),
+							"name":   plugin.StringData("Oralee"),
+							"age":    plugin.NumberData(31),
+							"height": plugin.NumberData(2.23),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "no_path_no_glob",
 			expectedDiags: [][]testtools.Assert{{
 				testtools.IsError,
-				testtools.SummaryContains("path is required"),
+				testtools.SummaryEquals("Failed to parse provided arguments"),
+				testtools.DetailEquals("Either \"glob\" value or \"path\" value must be provided"),
 			}},
 		},
 		{
@@ -99,13 +139,13 @@ func Test_fetchCSVData(t *testing.T) {
 			delimiter: "abc",
 			expectedDiags: [][]testtools.Assert{{
 				testtools.IsError,
-				testtools.SummaryContains("delimiter must be a single character"),
+				testtools.SummaryEquals("Delimiter must be a single character"),
 			}},
 		},
 		{
 			name: "default_delimiter",
 			path: "testdata/csv/comma.csv",
-			expectedRes: plugin.ListData{
+			expectedData: plugin.ListData{
 				plugin.MapData{
 					"id":     plugin.StringData("b8fa4bb0-6dd4-45ba-96e0-9a182b2b932e"),
 					"active": plugin.BoolData(true),
@@ -134,25 +174,29 @@ func Test_fetchCSVData(t *testing.T) {
 			path: "testdata/csv/does_not_exist.csv",
 			expectedDiags: [][]testtools.Assert{{
 				testtools.IsError,
-				testtools.SummaryContains("Failed to read csv file"),
-				testtools.DetailContains("no such file or directory"),
+				testtools.SummaryEquals("Failed to read a file"),
+				testtools.DetailEquals("open testdata/csv/does_not_exist.csv: no such file or directory"),
 			}},
 		},
-
+		{
+			name: "no_glob_matches",
+			glob: "testdata/csv/does_not_exist_*.csv",
+			expectedData: plugin.ListData{},
+		},
 		{
 			name: "invalid_csv",
 			path: "testdata/csv/invalid.csv",
 			expectedDiags: [][]testtools.Assert{{
 				testtools.IsError,
-				testtools.SummaryContains("Failed to read csv file"),
-				testtools.DetailContains("wrong number of fields"),
+				testtools.SummaryEquals("Failed to read a file"),
+				testtools.DetailEquals("record on line 2: wrong number of fields"),
 			}},
 		},
 		{
-			name:        "empty_csv",
-			path:        "testdata/csv/empty.csv",
-			delimiter:   ",",
-			expectedRes: plugin.ListData{},
+			name:      "empty_csv",
+			path:      "testdata/csv/empty.csv",
+			delimiter: ",",
+			expectedData: plugin.ListData{},
 		},
 	}
 
@@ -163,17 +207,29 @@ func Test_fetchCSVData(t *testing.T) {
 					"csv": makeCSVDataSource(),
 				},
 			}
+
 			config := ""
 			if tc.delimiter != "" {
 				config = fmt.Sprintf("delimiter = %q", tc.delimiter)
 			}
-			args := fmt.Sprintf("path = %q", tc.path)
+
+			args := make([]string, 0)
+			if tc.path != "" {
+				args = append(args, fmt.Sprintf("path = %q", tc.path))
+			}
+			if tc.glob != "" {
+				args = append(args, fmt.Sprintf("glob = %q", tc.glob))
+			}
+			argsBody := strings.Join(args, ",")
 
 			var diags diagnostics.Diag
-			argVal, diag := testtools.Decode(t, p.DataSources["csv"].Args, args)
+
+			argVal, diag := testtools.Decode(t, p.DataSources["csv"].Args, argsBody)
 			diags.Extend(diag)
+
 			cfgVal, diag := testtools.Decode(t, p.DataSources["csv"].Config, config)
 			diags.Extend(diag)
+
 			var data plugin.Data
 			if !diags.HasErrors() {
 				ctx := context.Background()
@@ -181,7 +237,7 @@ func Test_fetchCSVData(t *testing.T) {
 				data, dgs = p.RetrieveData(ctx, "csv", &plugin.RetrieveDataParams{Config: cfgVal, Args: argVal})
 				diags.ExtendHcl(dgs)
 			}
-			assert.Equal(t, tc.expectedRes, data)
+			assert.Equal(t, tc.expectedData, data)
 			testtools.CompareDiags(t, nil, diags, tc.expectedDiags)
 		})
 	}
@@ -191,7 +247,7 @@ func Test_readCSVFileCancellation(t *testing.T) {
 	const defaultCSVDelimiter = ','
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	data, err := readCSVFile(ctx, "testdata/csv/comma.csv", defaultCSVDelimiter)
+	data, err := readAndDecodeCSVFile(ctx, "testdata/csv/comma.csv", defaultCSVDelimiter)
 	assert.Nil(t, data)
 	assert.Error(t, context.Canceled, err)
 }

--- a/internal/builtin/data_json.go
+++ b/internal/builtin/data_json.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -21,27 +22,40 @@ func makeJSONDataSource() *plugin.DataSource {
 			&dataspec.AttrSpec{
 				Name:       "glob",
 				Type:       cty.String,
-				Required:   true,
-				ExampleVal: cty.StringVal("reports/*_data.json"),
-				Doc:        `A pattern that selects the json files to be read`,
+				Required:   false,
+				ExampleVal: cty.StringVal("data/*_alerts.json"),
+				Doc:        `A glob pattern to select JSON files for reading`,
+			},
+			&dataspec.AttrSpec{
+				Name:       "path",
+				Type:       cty.String,
+				Required:   false,
+				ExampleVal: cty.StringVal("data/alerts.json"),
+				Doc:        `A file path to a JSON file to read`,
 			},
 		},
 		Doc: `
-			Imports and parses the files matching "glob".
-			Results are presented using the following structure:
+			Loads JSON files with the names that match a provided "glob" pattern or a single file from a provided path.
+
+			Either "glob" value or "path" value must be provided.
+
+			When "path" is specified, only the content of the file is returned.
+			When "glob" is specified, the structure returned by the data source is a list of dicts with file data, for example:
 			` + "```json" + `
 			  [
 			    {
-			      "filename": "<name of the file matched by glob>",
-			      "contents": {
-			        "contents of the file": "parsed as json"
+			      "file_path": "path/file-a.json",
+			      "file_name": "file-a.json",
+			      "content": {
+			        "foo": "bar"
 			      },
 			    },
 			    {
-			      "filename": "<next file>",
-			      "contents": {
-			        "next": "contents"
-			      },
+			      "file_path": "path/file-b.json",
+			      "file_name": "file-b.json",
+			      "content": [
+			        {"x": "y"}
+			      ],
 			    }
 			  ]
 			` + "```",
@@ -49,55 +63,85 @@ func makeJSONDataSource() *plugin.DataSource {
 }
 
 func fetchJSONData(ctx context.Context, params *plugin.RetrieveDataParams) (plugin.Data, hcl.Diagnostics) {
+
 	glob := params.Args.GetAttr("glob")
-	if glob.IsNull() || glob.AsString() == "" {
-		return nil, hcl.Diagnostics{{
-			Severity: hcl.DiagError,
-			Summary:  "Failed to parse arguments",
-			Detail:   "glob is required",
-		}}
+	path := params.Args.GetAttr("path")
+
+	if !(path.IsNull() || path.AsString() == "") {
+		data, err := readAndDecodeFile(path.AsString())
+		if err != nil {
+			slog.Error(
+				"Error while reading a JSON file",
+				slog.String("path", path.AsString()),
+				slog.Any("error", err),
+			)
+			return nil, hcl.Diagnostics{{
+				Severity: hcl.DiagError,
+				Summary:  "Failed to read a JSON file",
+				Detail:   err.Error(),
+			}}
+		}
+		return data, nil
+	} else if !(glob.IsNull() || glob.AsString() == "") {
+		data, err := readJSONFiles(ctx, glob.AsString())
+		if err != nil {
+			slog.Error(
+				"Error while reading the JSON files",
+				slog.String("glob", glob.AsString()),
+				slog.Any("error", err),
+			)
+			return nil, hcl.Diagnostics{{
+				Severity: hcl.DiagError,
+				Summary:  "Failed to read JSON files from glob",
+				Detail:   err.Error(),
+			}}
+		}
+		return data, nil
 	}
-	data, err := readJSONFiles(ctx, glob.AsString())
-	if err != nil {
-		return nil, hcl.Diagnostics{{
-			Severity: hcl.DiagError,
-			Summary:  "Failed to read json files",
-			Detail:   err.Error(),
-		}}
-	}
-	return data, nil
+
+	slog.Error("Either \"glob\" value or \"path\" value must be provided")
+	return nil, hcl.Diagnostics{{
+		Severity: hcl.DiagError,
+		Summary:  "Failed to parse arguments",
+		Detail:   "Either \"glob\" value or \"path\" value must be provided",
+	}}
 }
 
-func readJSONFiles(ctx context.Context, pattern string) (plugin.ListData, error) {
-	matchers, err := filepath.Glob(pattern)
+func readAndDecodeFile(path string) (plugin.Data, error) {
+	file, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
-	result := make(plugin.ListData, 0, len(matchers))
-	for _, matcher := range matchers {
+	defer file.Close()
+
+	var content jsonData
+	err = json.NewDecoder(file).Decode(&content)
+	if err != nil {
+		file.Close()
+		return nil, err
+	}
+	return content.data, nil
+}
+
+func readJSONFiles(ctx context.Context, pattern string) (plugin.ListData, error) {
+	paths, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, err
+	}
+	result := make(plugin.ListData, 0, len(paths))
+	for _, path := range paths {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		default:
-			file, err := os.Open(matcher)
+			content, err := readAndDecodeFile(path)
 			if err != nil {
-				return nil, err
-			}
-			var contents jsonData
-			err = json.NewDecoder(file).Decode(&contents)
-			if err != nil {
-				file.Close()
-				return nil, err
+				return result, err
 			}
 			result = append(result, plugin.MapData{
-				"filename": plugin.StringData(matcher),
-				"contents": contents.data,
+				"path":    plugin.StringData(path),
+				"content": content,
 			})
-
-			err = file.Close()
-			if err != nil {
-				return nil, err
-			}
 		}
 	}
 	return result, nil

--- a/internal/builtin/data_txt.go
+++ b/internal/builtin/data_txt.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
@@ -17,13 +18,41 @@ func makeTXTDataSource() *plugin.DataSource {
 		DataFunc: fetchTXTData,
 		Args: dataspec.ObjectSpec{
 			&dataspec.AttrSpec{
+				Name:       "glob",
+				Type:       cty.String,
+				Required:   false,
+				ExampleVal: cty.StringVal("path/to/files*.txt"),
+				Doc:        `A glob pattern to select TXT files for reading`,
+			},
+			&dataspec.AttrSpec{
 				Name:       "path",
 				Type:       cty.String,
-				Required:   true,
-				ExampleVal: cty.StringVal("path/to/file.txt"),
+				Required:   false,
+				ExampleVal: cty.StringVal("data/disclaimer.txt"),
+				Doc:        `A file path to a TXT file to read`,
 			},
 		},
-		Doc: `Reads the file at "path" into a string`,
+		Doc: `
+			Loads TXT files with the names that match a provided "glob" pattern or a single file from a provided path.
+
+			Either "glob" value or "path" value must be provided.
+
+			When "path" is specified, only the content of the file is returned.
+			When "glob" is specified, the structure returned by the data source is a list of dicts with file data, for example:
+			` + "```json" + `
+			  [
+			    {
+			      "file_path": "path/file-a.txt",
+			      "file_name": "file-a.txt",
+			      "content": "foobar"
+			    },
+			    {
+			      "file_path": "path/file-b.txt",
+			      "file_name": "file-b.txt",
+			      "content": "x\\ny\\nz"
+			    }
+			  ]
+			` + "```",
 	}
 }
 
@@ -54,4 +83,25 @@ func fetchTXTData(ctx context.Context, params *plugin.RetrieveDataParams) (plugi
 		}}
 	}
 	return plugin.StringData(string(data)), nil
+}
+
+
+func readTXTFiles(ctx context.Context, pattern string, sep rune) (plugin.ListData, error) {
+	paths, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, err
+	}
+	result := make(plugin.ListData, 0, len(paths))
+	for _, path := range paths {
+		fileData, err := readCSVFile(ctx, path, sep)
+		if err != nil {
+			return result, err
+		}
+		result = append(result, plugin.MapData{
+			"file_path": plugin.StringData(path),
+			"file_name": plugin.StringData(filepath.Base(path)),
+			"content":   fileData,
+		})
+	}
+	return result, nil
 }

--- a/internal/testtools/diag.go
+++ b/internal/testtools/diag.go
@@ -110,11 +110,7 @@ func CompareDiags[D diagnostics.Generic](t *testing.T, fm map[string]*hcl.File, 
 
 func compareDiags(t *testing.T, fm map[string]*hcl.File, diags diagnostics.Diag, asserts [][]Assert) {
 	t.Helper()
-	// t.Logf("Verifying diagnostics with asserts. diags=%s, asserts=%s", diags, asserts)
 	if !matchBiject(t, diags, asserts) {
-		// 		var buf strings.Builder
-		// 		diagnostics.PrintDiags(&buf, diags, fm, false)
-		// 		t.Fatalf("\n\n%s", buf.String())
 		var b strings.Builder
 		b.WriteString("Actual diagnostics:\n")
 		for _, diag := range diags {

--- a/internal/testtools/diag.go
+++ b/internal/testtools/diag.go
@@ -1,6 +1,8 @@
 package testtools
 
 import (
+	"fmt"
+	"log/slog"
 	"strings"
 	"testing"
 
@@ -13,26 +15,77 @@ type (
 	Assert func(diag *hcl.Diagnostic) bool
 )
 
+func severityToString(severity any) string {
+	// Yep, that's how it is done
+	// https://github.com/hashicorp/hcl/blob/1c5ae8fc88a656ab7bd46da4ff27a20c5a97497b/diagnostic_text.go#L63-L72
+	var severityStr string
+	switch severity {
+	case hcl.DiagError:
+		severityStr = "Error"
+	case hcl.DiagWarning:
+		severityStr = "Warning"
+	default:
+		// should never happen
+		severityStr = "???????"
+	}
+	return severityStr
+}
+
 func IsError(diag *hcl.Diagnostic) bool {
-	return diag.Severity == hcl.DiagError
+	result := diag.Severity == hcl.DiagError
+	if !result {
+		slog.Error("Severity assert failed", "expected", severityToString(hcl.DiagError), "value", severityToString(diag.Severity))
+	}
+	return result
 }
 
 func IsWarning(diag *hcl.Diagnostic) bool {
-	return diag.Severity == hcl.DiagWarning
+	result := diag.Severity == hcl.DiagWarning
+	if !result {
+		slog.Error("Severity assert failed", "expected", severityToString(hcl.DiagWarning), "value", severityToString(diag.Severity))
+	}
+	return result
 }
 
 func SummaryContains(substrs ...string) Assert {
 	return func(diag *hcl.Diagnostic) bool {
-		return contains(diag.Summary, substrs)
+		result := contains(diag.Summary, substrs)
+		if !result {
+			slog.Error("Summary contains assert failed", "substrings", substrs, "value", diag.Summary)
+		}
+		return result
 	}
 }
 
 func DetailContains(substrs ...string) Assert {
 	return func(diag *hcl.Diagnostic) bool {
-		return contains(diag.Detail, substrs)
+		result := contains(diag.Detail, substrs)
+		if !result {
+			slog.Error("Detail contains assert failed", "substrings", substrs, "value", diag.Detail)
+		}
+		return result
 	}
 }
 
+func SummaryEquals(value string) Assert {
+	return func(diag *hcl.Diagnostic) bool {
+		result := diag.Summary == value
+		if !result {
+			slog.Error("Summary equals assert failed", "expected", value, "actual", diag.Summary)
+		}
+		return result
+	}
+}
+
+func DetailEquals(value string) Assert {
+	return func(diag *hcl.Diagnostic) bool {
+		result := diag.Detail == value
+		if !result {
+			slog.Error("Detail equals assert failed", "expected", value, "actual", diag.Detail)
+		}
+		return result
+	}
+}
 func contains(str string, substrs []string) bool {
 	str = strings.ToLower(str)
 	for _, substr := range substrs {
@@ -57,14 +110,25 @@ func CompareDiags[D diagnostics.Generic](t *testing.T, fm map[string]*hcl.File, 
 
 func compareDiags(t *testing.T, fm map[string]*hcl.File, diags diagnostics.Diag, asserts [][]Assert) {
 	t.Helper()
-	if !matchBiject(diags, asserts) {
-		var buf strings.Builder
-		diagnostics.PrintDiags(&buf, diags, fm, false)
-		t.Fatalf("\n\n%s", buf.String())
+	// t.Logf("Verifying diagnostics with asserts. diags=%s, asserts=%s", diags, asserts)
+	if !matchBiject(t, diags, asserts) {
+		// 		var buf strings.Builder
+		// 		diagnostics.PrintDiags(&buf, diags, fm, false)
+		// 		t.Fatalf("\n\n%s", buf.String())
+		var b strings.Builder
+		b.WriteString("Actual diagnostics:\n")
+		for _, diag := range diags {
+			b.WriteString("\n")
+			b.WriteString(fmt.Sprintf("[Severity]: %s\n", severityToString(diag.Severity)))
+			b.WriteString(fmt.Sprintf("[Summary]: %s\n", diag.Summary))
+			b.WriteString(fmt.Sprintf("[Details]: %s\n", diag.Detail))
+			b.WriteString("\n")
+		}
+		t.Fatal(b.String())
 	}
 }
 
-func matchBiject(diags diagnostics.Diag, asserts [][]Assert) bool {
+func matchBiject(t *testing.T, diags diagnostics.Diag, asserts [][]Assert) bool {
 	dgs := []*hcl.Diagnostic(diags)
 	if len(dgs) != len(asserts) {
 		return false
@@ -74,8 +138,9 @@ nextDiag:
 	for _, diag := range dgs {
 	nextAssertSet:
 		for assertSetIdx, assertSet := range asserts {
-			for _, assert := range assertSet {
-				if !assert(diag) {
+			for _, a := range assertSet {
+				if !a(diag) {
+					t.Logf("Assert didn't match the diagnostic")
 					continue nextAssertSet
 				}
 			}

--- a/internal/testtools/diag.go
+++ b/internal/testtools/diag.go
@@ -136,7 +136,6 @@ nextDiag:
 		for assertSetIdx, assertSet := range asserts {
 			for _, a := range assertSet {
 				if !a(diag) {
-					t.Logf("Assert didn't match the diagnostic")
 					continue nextAssertSet
 				}
 			}

--- a/internal/testtools/testtools.go
+++ b/internal/testtools/testtools.go
@@ -68,6 +68,7 @@ func Decode(t *testing.T, spec dataspec.RootSpec, body string) (v cty.Value, dia
 	if diags.ExtendHcl(diag) {
 		return
 	}
+
 	v, diag = hcldec.Decode(f.Body, spec.HcldecSpec(), nil)
 	diags = append(diags, diag...)
 	return

--- a/internal/testtools/testtools.go
+++ b/internal/testtools/testtools.go
@@ -68,7 +68,6 @@ func Decode(t *testing.T, spec dataspec.RootSpec, body string) (v cty.Value, dia
 	if diags.ExtendHcl(diag) {
 		return
 	}
-
 	v, diag = hcldec.Decode(f.Body, spec.HcldecSpec(), nil)
 	diags = append(diags, diag...)
 	return

--- a/justfile
+++ b/justfile
@@ -23,6 +23,9 @@ test:
 test-pretty:
     gotestsum --format dots-v2 -- -timeout 10s -race -short -v ./...
 
+test-pretty-one testname:
+    gotestsum --format dots-v2 -- -timeout 10s -race -short -v ./... -run {{ testname }}
+
 test-all:
     go test -timeout 5m -race -v ./...
 


### PR DESCRIPTION
## What was changed

- `txt`, `csv` and `json` data sources were adjusted to support both `path` and `glob` parameters
- the unit tests were updated

Fixes https://github.com/blackstork-io/fabric/issues/176