### PR TITLE
Implement scrolling search in `data.elasticsearch` data source

### DIFF
--- a/internal/elastic/data_elastic_security_cases.go
+++ b/internal/elastic/data_elastic_security_cases.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	minSize     = 1
-	defaultSize = 10
+	minCasesSize     = 1
+	defaultCasesSize = 10
 )
 
 func makeElasticSecurityCasesDataSource(loader KibanaClientLoaderFn) *plugin.DataSource {
@@ -120,11 +120,11 @@ func fetchElasticSecurityCases(loader KibanaClientLoaderFn) plugin.RetrieveDataF
 				Detail:   err.Error(),
 			}}
 		}
-		size := defaultSize
+		size := defaultCasesSize
 		if attr := params.Args.GetAttr("size"); !attr.IsNull() {
 			num, _ := attr.AsBigFloat().Int64()
 			size = int(num)
-			if size < minSize {
+			if size < minCasesSize {
 				return nil, hcl.Diagnostics{{
 					Severity: hcl.DiagError,
 					Summary:  "Invalid size",

--- a/internal/elastic/data_elasticsearch_test.go
+++ b/internal/elastic/data_elasticsearch_test.go
@@ -520,6 +520,10 @@ func (s *IntegrationTestSuite) TestScrollSearchSteps() {
 		"fields":       cty.NullVal(cty.String),
 		"size":         cty.NumberIntVal(5),  // does not matter
 	})
+	// There are only 3 results, so with the size 5 and step size 1,
+	// we should hit 4 requests:
+	// - initial search request (1 result)
+	// - 3 scroll requests: 2 with 1 result and one with an empty result to break the loop
 	data, err := searchWithScrollConfigurable(s.client, args, 5, 1)
 
 	s.Require().Nil(err, fmt.Sprintf("Received diagnostics: %s", err))

--- a/internal/elastic/plugin.go
+++ b/internal/elastic/plugin.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
+	"time"
 
 	es "github.com/elastic/go-elasticsearch/v8"
 	"github.com/elastic/go-elasticsearch/v8/esapi"
@@ -17,8 +19,8 @@ import (
 )
 
 const (
-	defaultBaseURL  = "http://localhost:9200"
 	defaultUsername = "elastic"
+	defaultScrollStepSize  = 1000
 )
 
 type KibanaClientLoaderFn func(url string, apiKey *string) kbclient.Client
@@ -121,7 +123,194 @@ func getByID(fn esapi.Get, args cty.Value) (plugin.Data, error) {
 	return data, nil
 }
 
-func search(fn esapi.Search, args cty.Value) (plugin.Data, error) {
+func unpackSearchOptions(fn esapi.Search, args cty.Value) ([]func(*esapi.SearchRequest), error) {
+	index := args.GetAttr("index")
+	if index.IsNull() {
+		return nil, fmt.Errorf("index is required")
+	}
+	opts := []func(*esapi.SearchRequest){
+		fn.WithIndex(index.AsString()),
+	}
+
+	if queryString := args.GetAttr("query_string"); !queryString.IsNull() {
+		opts = append(opts, fn.WithQuery(queryString.AsString()))
+	}
+	body := map[string]any{}
+	if query := args.GetAttr("query"); !query.IsNull() {
+		raw, err := ctyjson.Marshal(query, query.Type())
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal query: %s", err)
+		}
+		body["query"] = json.RawMessage(raw)
+
+	}
+	if aggs := args.GetAttr("aggs"); !aggs.IsNull() {
+		raw, err := ctyjson.Marshal(aggs, aggs.Type())
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal aggs: %s", err)
+		}
+		body["aggs"] = json.RawMessage(raw)
+	}
+	if len(body) > 0 {
+		rawBody, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal query: %s", err)
+		}
+		opts = append(opts, fn.WithBody(bytes.NewReader(rawBody)))
+	}
+	if fields := args.GetAttr("fields"); !fields.IsNull() {
+		fieldSlice := fields.AsValueSlice()
+		fieldStrings := make([]string, len(fieldSlice))
+		for i, v := range fieldSlice {
+			fieldStrings[i] = v.AsString()
+		}
+		opts = append(opts, fn.WithSource(fieldStrings...))
+	}
+	return opts, nil
+}
+
+func unpackResponse(response *esapi.Response) (plugin.MapData, error) {
+	// Read the response
+	raw, err := io.ReadAll(response.Body)
+	defer response.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read the search response: %s", err)
+	}
+	data, err := plugin.UnmarshalJSONData(raw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal the search response: %s", err)
+	}
+	mapData, ok := data.(plugin.MapData)
+	if !ok {
+		return nil, fmt.Errorf("unexpected search result type: %T", data)
+	}
+	return mapData, nil
+}
+
+func searchWithScroll(client *es.Client, args cty.Value, size int) (plugin.Data, error) {
+	return searchWithScrollConfigurable(client, args, size, defaultScrollStepSize)
+}
+
+func searchWithScrollConfigurable(client *es.Client, args cty.Value, size int, stepSize int) (plugin.Data, error) {
+
+	// First scroll request to obtain `_scroll_id`
+	scrollTTL := time.Minute * 2 // 2mins
+	// just in case the size is smaller than the step size
+	reqSize := min(size, stepSize)
+
+	requestsCounter := 0
+
+	opts, err := unpackSearchOptions(client.Search, args)
+	if err != nil {
+		return nil, err
+	}
+	opts = append(opts, client.Search.WithScroll(scrollTTL))
+	opts = append(opts, client.Search.WithSize(reqSize))
+
+	slog.Debug(
+		"Sending an initial scroll search request",
+		"size", reqSize,
+		"scroll_ttl", scrollTTL,
+	)
+	requestsCounter += 1
+	res, err := client.Search(opts...)
+	if err != nil {
+		return nil, err
+	} else if res.IsError() {
+		return nil, fmt.Errorf("failed to perform a search: %s", res.String())
+	}
+
+	firstData, err := unpackResponse(res)
+	if err != nil {
+		return nil, err
+	}
+	scrollIDRaw, ok := firstData["_scroll_id"]
+	if !ok {
+		return nil, fmt.Errorf("error while getting scroll id value: %s", firstData)
+	}
+	scrollID := scrollIDRaw.(plugin.StringData)
+
+	hitsEnvelope, ok := firstData["hits"].(plugin.MapData)
+	if !ok {
+		return nil, fmt.Errorf("unexpected hits envelope value type: %T", firstData)
+	}
+	hits, ok := hitsEnvelope["hits"].(plugin.ListData)
+	if !ok {
+		return nil, fmt.Errorf("unexpected hits value type: %T", firstData)
+	}
+	allHits := make(plugin.ListData, 0, len(hits))
+	allHits = append(allHits, hits...)
+
+	for {
+		if len(allHits) >= size {
+			break
+		}
+
+		// just in case the leftover size is smaller than the step size
+		reqSize := min((size - len(allHits)), stepSize)
+		if reqSize <= 0 {
+			break
+		}
+
+		slog.Debug(
+			"Sending a scroll search request",
+			"scroll_id", scrollID,
+			"scroll_ttl", scrollTTL,
+			"size", reqSize,
+			"hits_count", len(allHits),
+		)
+		requestsCounter += 1
+		res, err = client.Scroll(
+			client.Scroll.WithScrollID(string(scrollID)),
+			client.Scroll.WithScroll(scrollTTL),
+		)
+
+		if err != nil {
+			return nil, err
+		} else if res.IsError() {
+			return nil, fmt.Errorf("failed to perform a scroll search: %s", res.String())
+		}
+
+		scrollData, err := unpackResponse(res)
+
+		if err != nil {
+			return nil, err
+		}
+		scrollIDRaw, ok = scrollData["_scroll_id"]
+		if !ok {
+			return nil, fmt.Errorf("error while getting scroll id value: %s", scrollData)
+		}
+		scrollID = scrollIDRaw.(plugin.StringData)
+
+		hitsEnvelope, ok := scrollData["hits"].(plugin.MapData)
+		if !ok {
+			return nil, fmt.Errorf("unexpected hits envelope value type: %T", firstData)
+		}
+		hits, ok := hitsEnvelope["hits"].(plugin.ListData)
+		if !ok {
+			return nil, fmt.Errorf("unexpected hits value type: %T", scrollData)
+		}
+
+		if len(hits) == 0 {
+			break
+		}
+		allHits = append(allHits, hits...)
+	}
+
+	slog.Debug(
+		"Scroll search finished",
+		"hits_count", len(allHits),
+		"requests_count", requestsCounter,
+	)
+	if onlyHits := args.GetAttr("only_hits"); onlyHits.IsNull() || onlyHits.True() {
+		return allHits, nil
+	}
+	// Update and return the first returned data to keep the aggregations
+	hitsEnvelope["hits"] = allHits
+	return firstData, nil
+}
+
+func search(fn esapi.Search, args cty.Value, size int) (plugin.Data, error) {
 	index := args.GetAttr("index")
 	if index.IsNull() {
 		return nil, fmt.Errorf("index is required")
@@ -155,13 +344,6 @@ func search(fn esapi.Search, args cty.Value) (plugin.Data, error) {
 		}
 		opts = append(opts, fn.WithBody(bytes.NewReader(rawBody)))
 	}
-	if size := args.GetAttr("size"); !size.IsNull() {
-		n, _ := size.AsBigFloat().Int64()
-		if n < 0 {
-			return nil, fmt.Errorf("size must be greater than 0")
-		}
-		opts = append(opts, fn.WithSize(int(n)))
-	}
 	if fields := args.GetAttr("fields"); !fields.IsNull() {
 		fieldSlice := fields.AsValueSlice()
 		fieldStrings := make([]string, len(fieldSlice))
@@ -170,6 +352,8 @@ func search(fn esapi.Search, args cty.Value) (plugin.Data, error) {
 		}
 		opts = append(opts, fn.WithSource(fieldStrings...))
 	}
+	opts = append(opts, fn.WithSize(size))
+
 	res, err := fn(opts...)
 	if err != nil {
 		return nil, err
@@ -190,7 +374,8 @@ func search(fn esapi.Search, args cty.Value) (plugin.Data, error) {
 	return data, nil
 }
 
-func extractHits(data plugin.Data) (plugin.Data, error) {
+func extractHits(data plugin.Data) (plugin.ListData, error) {
+	// Unpack the result as a map
 	m, ok := data.(plugin.MapData)
 	if !ok {
 		return nil, fmt.Errorf("unexpected search result type: %T", data)
@@ -199,9 +384,10 @@ func extractHits(data plugin.Data) (plugin.Data, error) {
 	if !ok {
 		return nil, fmt.Errorf("unexpected search result type: %T", data)
 	}
+	// Unpack "hits" value as a map
 	m, ok = data.(plugin.MapData)
 	if !ok {
 		return nil, fmt.Errorf("unexpected search result type: %T", data)
 	}
-	return m["hits"], nil
+	return m["hits"].(plugin.ListData), nil
 }

--- a/internal/elastic/plugin.go
+++ b/internal/elastic/plugin.go
@@ -19,8 +19,8 @@ import (
 )
 
 const (
-	defaultUsername = "elastic"
-	defaultScrollStepSize  = 1000
+	defaultUsername       = "elastic"
+	defaultScrollStepSize = 1000
 )
 
 type KibanaClientLoaderFn func(url string, apiKey *string) kbclient.Client


### PR DESCRIPTION
## What was changed

- `searchWithScroll` and `searchWithScrollConfigurable` functions were added:
  - the functions implement Elasticsearch scroll search logic (with `searchWithScrollConfigurable` accepting a step size as input param, for testing)
  - the data source will use a simple search if the requested size is <= `maxSimpleSearchResultsSize` (`10000`), and use scrolling search otherwise 
- 2 integration tests added to verify that the data source makes a correct selection with the large size, and to verify that the multiple-search-steps logic works
- small naming fix for Elastic cases data source 

Fixes https://github.com/blackstork-io/fabric/issues/167