### PR TITLE
String length checks respect multibyte encodings

### DIFF
--- a/plugin/dataspec/attr.go
+++ b/plugin/dataspec/attr.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hcldec"
@@ -223,7 +224,7 @@ func (a *AttrSpec) ValidateValue(val cty.Value) (diags hcl.Diagnostics) {
 		if val.Type().IsCollectionType() || val.Type().IsTupleType() {
 			length = val.LengthInt()
 		} else if val.Type().IsPrimitiveType() && val.Type() == cty.String {
-			length = len(val.AsString())
+			length = utf8.RuneCountInString(val.AsString())
 		}
 		min := a.computeMinInclusive()
 		max := a.MaxInclusive

--- a/plugin/dataspec/attr_test.go
+++ b/plugin/dataspec/attr_test.go
@@ -150,6 +150,19 @@ func TestValidation(t *testing.T) {
 			},
 		},
 		{
+			name: "Length_check_correct_utf8_multibyte",
+			obj: &dataspec.AttrSpec{
+				Name:         "test",
+				Type:         cty.String,
+				DefaultVal:   cty.StringVal(";"),
+				MinInclusive: cty.NumberIntVal(1),
+				MaxInclusive: cty.NumberIntVal(1),
+			},
+			inputVal:    cty.StringVal("😭"),
+			asserts:     diagtest.Asserts{},
+			expectedVal: cty.StringVal("😭"),
+		},
+		{
 			name: "Length_check_max",
 			obj: &dataspec.AttrSpec{
 				Name:         "test",


### PR DESCRIPTION
Woops, length checks (`MinInclusive`/`MaxInclusive`) were checking string length in bytes, not in runes.