### PR TITLE
Adjust `txt`, `csv` and `json` data sources to accept both `path` and `glob` attributes

### DIFF
--- a/docs/plugins/builtin/data-sources/csv.md
+++ b/docs/plugins/builtin/data-sources/csv.md
@@ -2,7 +2,7 @@
 title: csv
 plugin:
   name: blackstork/builtin
-  description: "Imports and parses a csv file"
+  description: "Loads CSV files with the names that match a provided \"glob\" pattern or a single file from a provided path"
   tags: []
   version: "v0.4.1"
   source_github: "https://github.com/blackstork-io/fabric/tree/main/internal/builtin/"
@@ -16,22 +16,50 @@ type: docs
 {{< plugin-resource-header "blackstork/builtin" "builtin" "v0.4.1" "csv" "data source" >}}
 
 ## Description
-Imports and parses a csv file.
+Loads CSV files with the names that match a provided "glob" pattern or a single file from a provided path.
 
-We assume the table has a header and turn each line into a map based on the header titles.
+Either "glob" or "path" attribute must be set.
 
-For example following table
+When "path" attribute is specified, the data source returns only the content of a file.
+When "glob" attribute is specified, the data source returns a list of dicts that contain the content of a file and file's metadata.
+
+Note: the data source assumes that CSV file has a header and turns each line into a map with column titles as keys.
+
+For example, CSV file with the following data:
 
 | column_A | column_B | column_C |
 | -------- | -------- | -------- |
-| Test     | true     | 42       |
-| Line 2   | false    | 4.2      |
+| Foo      | true     | 42       |
+| Bar      | false    | 4.2      |
 
-will be represented as the following structure:
+will be represented as the following data structure:
 ```json
 [
-  {"column_A": "Test", "column_B": true, "column_C": 42},
-  {"column_A": "Line 2", "column_B": false, "column_C": 4.2}
+  {"column_A": "Foo", "column_B": true, "column_C": 42},
+  {"column_A": "Bar", "column_B": false, "column_C": 4.2}
+]
+```
+
+When "glob" is used and multiple files match the pattern, the data source will return a list of dicts, for example:
+
+```json
+[
+  {
+    "file_path": "path/file-a.csv",
+    "file_name": "file-a.csv",
+    "content": [
+      {"column_A": "Foo", "column_B": true, "column_C": 42},
+      {"column_A": "Bar", "column_B": false, "column_C": 4.2}
+    ]
+  },
+  {
+    "file_path": "path/file-b.csv",
+    "file_name": "file-b.csv",
+    "content": [
+      {"column_C": "Baz", "column_D": 1},
+      {"column_C": "Clu", "column_D": 2}
+    ]
+  },
 ]
 ```
 
@@ -58,9 +86,22 @@ The data source supports the following parameters in the data blocks:
 
 ```hcl
 data csv {
-  # Required string.
-  # Must have a length of at least 1
+  # A glob pattern to select CSV files to read
+  #
+  # Optional string.
   # For example:
-  path = "path/to/file.csv"
+  # glob = "path/to/file*.csv"
+  # 
+  # Default value:
+  glob = null
+
+  # A file path to a CSV file to read
+  #
+  # Optional string.
+  # For example:
+  # path = "path/to/file.csv"
+  # 
+  # Default value:
+  path = null
 }
 ```

--- a/docs/plugins/builtin/data-sources/json.md
+++ b/docs/plugins/builtin/data-sources/json.md
@@ -2,7 +2,7 @@
 title: json
 plugin:
   name: blackstork/builtin
-  description: "Imports and parses the files matching \"glob\""
+  description: "Loads JSON files with the names that match a provided \"glob\" pattern or a single file from a provided path"
   tags: []
   version: "v0.4.1"
   source_github: "https://github.com/blackstork-io/fabric/tree/main/internal/builtin/"
@@ -16,23 +16,29 @@ type: docs
 {{< plugin-resource-header "blackstork/builtin" "builtin" "v0.4.1" "json" "data source" >}}
 
 ## Description
-Imports and parses the files matching "glob".
-Results are presented using the following structure:
+Loads JSON files with the names that match a provided "glob" pattern or a single file from a provided path.
+
+Either "glob" or "path" attribute must be set.
+
+When "path" attribute is specified, the data source returns only the content of a file.
+When "glob" attribute is specified, the data source returns a list of dicts that contain the content of a file and file's metadata. For example:
 ```json
-  [
-    {
-      "filename": "<name of the file matched by glob>",
-      "contents": {
-        "contents of the file": "parsed as json"
-      },
+[
+  {
+    "file_path": "path/file-a.json",
+    "file_name": "file-a.json",
+    "content": {
+      "foo": "bar"
     },
-    {
-      "filename": "<next file>",
-      "contents": {
-        "next": "contents"
-      },
-    }
-  ]
+  },
+  {
+    "file_path": "path/file-b.json",
+    "file_name": "file-b.json",
+    "content": [
+      {"x": "y"}
+    ],
+  }
+]
 ```
 
 The data source is built-in, which means it's a part of `fabric` binary. It's available out-of-the-box, no installation required.
@@ -47,10 +53,22 @@ The data source supports the following parameters in the data blocks:
 
 ```hcl
 data json {
-  # A pattern that selects the json files to be read
+  # A glob pattern to select JSON files to read
   #
-  # Required string.
+  # Optional string.
   # For example:
-  glob = "reports/*_data.json"
+  # glob = "path/to/file*.json"
+  # 
+  # Default value:
+  glob = null
+
+  # A file path to a JSON file to read
+  #
+  # Optional string.
+  # For example:
+  # path = "path/to/file.json"
+  # 
+  # Default value:
+  path = null
 }
 ```

--- a/docs/plugins/builtin/data-sources/txt.md
+++ b/docs/plugins/builtin/data-sources/txt.md
@@ -2,7 +2,7 @@
 title: txt
 plugin:
   name: blackstork/builtin
-  description: "Reads the file at \"path\" into a string"
+  description: "Loads TXT files with the names that match a provided \"glob\" pattern or a single file from a provided path"
   tags: []
   version: "v0.4.1"
   source_github: "https://github.com/blackstork-io/fabric/tree/main/internal/builtin/"
@@ -16,7 +16,26 @@ type: docs
 {{< plugin-resource-header "blackstork/builtin" "builtin" "v0.4.1" "txt" "data source" >}}
 
 ## Description
-Reads the file at "path" into a string
+Loads TXT files with the names that match a provided "glob" pattern or a single file from a provided path.
+
+Either "glob" or "path" attribute must be set.
+
+When "path" attribute is specified, the data source returns only the content of a file.
+When "glob" attribute is specified, the data source returns a list of dicts that contain the content of a file and file's metadata. For example:
+```json
+[
+  {
+    "file_path": "path/file-a.txt",
+    "file_name": "file-a.txt",
+    "content": "foobar"
+  },
+  {
+    "file_path": "path/file-b.txt",
+    "file_name": "file-b.txt",
+    "content": "x\\ny\\nz"
+  }
+]
+```
 
 The data source is built-in, which means it's a part of `fabric` binary. It's available out-of-the-box, no installation required.
 
@@ -30,8 +49,22 @@ The data source supports the following parameters in the data blocks:
 
 ```hcl
 data txt {
-  # Required string.
+  # A glob pattern to select TXT files to read
+  #
+  # Optional string.
   # For example:
-  path = "path/to/file.txt"
+  # glob = "path/to/file*.txt"
+  # 
+  # Default value:
+  glob = null
+
+  # A file path to a TXT file to read
+  #
+  # Optional string.
+  # For example:
+  # path = "path/to/file.txt"
+  # 
+  # Default value:
+  path = null
 }
 ```

--- a/docs/plugins/plugins.json
+++ b/docs/plugins/plugins.json
@@ -26,6 +26,7 @@
           "delimiter"
         ],
         "arguments": [
+          "glob",
           "path"
         ]
       },
@@ -53,7 +54,8 @@
         "name": "json",
         "type": "data-source",
         "arguments": [
-          "glob"
+          "glob",
+          "path"
         ]
       },
       {
@@ -118,6 +120,7 @@
         "name": "txt",
         "type": "data-source",
         "arguments": [
+          "glob",
           "path"
         ]
       }

--- a/internal/builtin/data_csv_test.go
+++ b/internal/builtin/data_csv_test.go
@@ -3,6 +3,8 @@ package builtin
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,18 +25,21 @@ func Test_makeCSVDataSchema(t *testing.T) {
 }
 
 func Test_fetchCSVData(t *testing.T) {
+	slog.SetLogLoggerLevel(slog.LevelDebug)
+
 	tt := []struct {
 		name          string
 		path          string
+		glob          string
 		delimiter     string
-		expectedRes   plugin.Data
+		expectedData  plugin.Data
 		expectedDiags diagtest.Asserts
 	}{
 		{
-			name:      "comma_delim",
+			name:      "comma_delim_path",
 			path:      "testdata/csv/comma.csv",
 			delimiter: ",",
-			expectedRes: plugin.ListData{
+			expectedData: plugin.ListData{
 				plugin.MapData{
 					"id":     plugin.StringData("b8fa4bb0-6dd4-45ba-96e0-9a182b2b932e"),
 					"active": plugin.BoolData(true),
@@ -59,10 +64,10 @@ func Test_fetchCSVData(t *testing.T) {
 			},
 		},
 		{
-			name:      "semicolon_delim",
+			name:      "semicolon_delim_path",
 			path:      "testdata/csv/semicolon.csv",
 			delimiter: ";",
-			expectedRes: plugin.ListData{
+			expectedData: plugin.ListData{
 				plugin.MapData{
 					"id":     plugin.StringData("b8fa4bb0-6dd4-45ba-96e0-9a182b2b932e"),
 					"active": plugin.BoolData(true),
@@ -87,10 +92,45 @@ func Test_fetchCSVData(t *testing.T) {
 			},
 		},
 		{
-			name: "empty_path",
+			name:      "comma_delim_glob",
+			glob:      "testdata/csv/comm*.csv",
+			delimiter: ",",
+			expectedData: plugin.ListData{
+				plugin.MapData{
+					"file_name": plugin.StringData("comma.csv"),
+					"file_path": plugin.StringData("testdata/csv/comma.csv"),
+					"content": plugin.ListData{
+						plugin.MapData{
+							"id":     plugin.StringData("b8fa4bb0-6dd4-45ba-96e0-9a182b2b932e"),
+							"active": plugin.BoolData(true),
+							"name":   plugin.StringData("Stacey"),
+							"age":    plugin.NumberData(26),
+							"height": plugin.NumberData(1.98),
+						},
+						plugin.MapData{
+							"id":     plugin.StringData("b0086c49-bcd8-4aae-9f88-4f46b128e709"),
+							"active": plugin.BoolData(false),
+							"name":   plugin.StringData("Myriam"),
+							"age":    plugin.NumberData(33),
+							"height": plugin.NumberData(1.81),
+						},
+						plugin.MapData{
+							"id":     plugin.StringData("a12d2a8c-eebc-42b3-be52-1ab0a2969a81"),
+							"active": plugin.BoolData(true),
+							"name":   plugin.StringData("Oralee"),
+							"age":    plugin.NumberData(31),
+							"height": plugin.NumberData(2.23),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "no_path_no_glob",
 			expectedDiags: diagtest.Asserts{{
 				diagtest.IsError,
-				diagtest.DetailContains(`length`, `"path"`, `>= 1`),
+				diagtest.SummaryEquals("Failed to parse provided arguments"),
+				diagtest.DetailEquals("Either \"glob\" value or \"path\" value must be provided"),
 			}},
 		},
 		{
@@ -107,7 +147,7 @@ func Test_fetchCSVData(t *testing.T) {
 		{
 			name: "default_delimiter",
 			path: "testdata/csv/comma.csv",
-			expectedRes: plugin.ListData{
+			expectedData: plugin.ListData{
 				plugin.MapData{
 					"id":     plugin.StringData("b8fa4bb0-6dd4-45ba-96e0-9a182b2b932e"),
 					"active": plugin.BoolData(true),
@@ -136,7 +176,7 @@ func Test_fetchCSVData(t *testing.T) {
 			path: "testdata/csv/does_not_exist.csv",
 			expectedDiags: diagtest.Asserts{{
 				diagtest.IsError,
-				diagtest.SummaryContains("Failed to read csv file"),
+				diagtest.SummaryContains("Failed to read a file"),
 				diagtest.DetailContains("no such file or directory"),
 			}},
 		},
@@ -146,15 +186,15 @@ func Test_fetchCSVData(t *testing.T) {
 			path: "testdata/csv/invalid.csv",
 			expectedDiags: diagtest.Asserts{{
 				diagtest.IsError,
-				diagtest.SummaryContains("Failed to read csv file"),
-				diagtest.DetailContains("wrong number of fields"),
+				diagtest.SummaryContains("Failed to read a file"),
+				diagtest.DetailEquals("record on line 2: wrong number of fields"),
 			}},
 		},
 		{
-			name:        "empty_csv",
-			path:        "testdata/csv/empty.csv",
-			delimiter:   ",",
-			expectedRes: plugin.ListData{},
+			name:         "empty_csv",
+			path:         "testdata/csv/empty.csv",
+			delimiter:    ",",
+			expectedData: plugin.ListData{},
 		},
 	}
 
@@ -169,10 +209,18 @@ func Test_fetchCSVData(t *testing.T) {
 			if tc.delimiter != "" {
 				config = fmt.Sprintf("delimiter = %q", tc.delimiter)
 			}
-			args := fmt.Sprintf("path = %q", tc.path)
+
+			args := make([]string, 0)
+			if tc.path != "" {
+				args = append(args, fmt.Sprintf("path = %q", tc.path))
+			}
+			if tc.glob != "" {
+				args = append(args, fmt.Sprintf("glob = %q", tc.glob))
+			}
+			argsBody := strings.Join(args, ",")
 
 			var diags diagnostics.Diag
-			argVal, diag := plugintest.Decode(t, p.DataSources["csv"].Args, args)
+			argVal, diag := plugintest.Decode(t, p.DataSources["csv"].Args, argsBody)
 			diags.Extend(diag)
 			cfgVal, diag := plugintest.Decode(t, p.DataSources["csv"].Config, config)
 			diags.Extend(diag)
@@ -183,7 +231,7 @@ func Test_fetchCSVData(t *testing.T) {
 				data, dgs = p.RetrieveData(ctx, "csv", &plugin.RetrieveDataParams{Config: cfgVal, Args: argVal})
 				diags.Extend(dgs)
 			}
-			assert.Equal(t, tc.expectedRes, data)
+			assert.Equal(t, tc.expectedData, data)
 			tc.expectedDiags.AssertMatch(t, diags, nil)
 		})
 	}
@@ -193,7 +241,7 @@ func Test_readCSVFileCancellation(t *testing.T) {
 	const defaultCSVDelimiter = ','
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	data, err := readCSVFile(ctx, "testdata/csv/comma.csv", defaultCSVDelimiter)
+	data, err := readAndDecodeCSVFile(ctx, "testdata/csv/comma.csv", defaultCSVDelimiter)
 	assert.Nil(t, data)
 	assert.Error(t, context.Canceled, err)
 }

--- a/internal/builtin/data_txt.go
+++ b/internal/builtin/data_txt.go
@@ -3,7 +3,9 @@ package builtin
 import (
 	"context"
 	"io"
+	"log/slog"
 	"os"
+	"path/filepath"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
@@ -11,7 +13,6 @@ import (
 	"github.com/blackstork-io/fabric/pkg/diagnostics"
 	"github.com/blackstork-io/fabric/plugin"
 	"github.com/blackstork-io/fabric/plugin/dataspec"
-	"github.com/blackstork-io/fabric/plugin/dataspec/constraint"
 )
 
 func makeTXTDataSource() *plugin.DataSource {
@@ -19,30 +20,48 @@ func makeTXTDataSource() *plugin.DataSource {
 		DataFunc: fetchTXTData,
 		Args: dataspec.ObjectSpec{
 			&dataspec.AttrSpec{
-				Name:        "path",
-				Type:        cty.String,
-				Constraints: constraint.RequiredNonNull,
-				ExampleVal:  cty.StringVal("path/to/file.txt"),
+				Name:       "glob",
+				Type:       cty.String,
+				ExampleVal: cty.StringVal("path/to/file*.txt"),
+				Doc:        `A glob pattern to select TXT files to read`,
+			},
+			&dataspec.AttrSpec{
+				Name:       "path",
+				Type:       cty.String,
+				ExampleVal: cty.StringVal("path/to/file.txt"),
+				Doc:        `A file path to a TXT file to read`,
 			},
 		},
-		Doc: `Reads the file at "path" into a string`,
+		Doc: `
+		Loads TXT files with the names that match a provided "glob" pattern or a single file from a provided path.
+
+		Either "glob" or "path" attribute must be set.
+
+		When "path" attribute is specified, the data source returns only the content of a file.
+		When "glob" attribute is specified, the data source returns a list of dicts that contain the content of a file and file's metadata. For example:
+		` + "```json" + `
+		[
+		  {
+			"file_path": "path/file-a.txt",
+			"file_name": "file-a.txt",
+			"content": "foobar"
+		  },
+		  {
+			"file_path": "path/file-b.txt",
+			"file_name": "file-b.txt",
+			"content": "x\\ny\\nz"
+		  }
+		]
+		` + "```",
 	}
 }
 
-func fetchTXTData(ctx context.Context, params *plugin.RetrieveDataParams) (plugin.Data, diagnostics.Diag) {
-	path := params.Args.GetAttr("path")
-	if path.IsNull() || path.AsString() == "" {
-		return nil, diagnostics.Diag{{
-			Severity: hcl.DiagError,
-			Summary:  "Failed to parse arguments",
-			Detail:   "path is required",
-		}}
-	}
-	f, err := os.Open(path.AsString())
+func readTXTFile(path string) (plugin.Data, error) {
+	f, err := os.Open(path)
 	if err != nil {
 		return nil, diagnostics.Diag{{
 			Severity: hcl.DiagError,
-			Summary:  "Failed to open txt file",
+			Summary:  "Failed to open a file",
 			Detail:   err.Error(),
 		}}
 	}
@@ -51,9 +70,75 @@ func fetchTXTData(ctx context.Context, params *plugin.RetrieveDataParams) (plugi
 	if err != nil {
 		return nil, diagnostics.Diag{{
 			Severity: hcl.DiagError,
-			Summary:  "Failed to read txt file",
+			Summary:  "Failed to read a file",
 			Detail:   err.Error(),
 		}}
 	}
 	return plugin.StringData(string(data)), nil
+}
+
+func readTXTFiles(ctx context.Context, pattern string) (plugin.Data, error) {
+	paths, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, err
+	}
+	result := make(plugin.ListData, 0, len(paths))
+	for _, path := range paths {
+		fileData, err := readTXTFile(path)
+		if err != nil {
+			return result, err
+		}
+		result = append(result, plugin.MapData{
+			"file_path": plugin.StringData(path),
+			"file_name": plugin.StringData(filepath.Base(path)),
+			"content":   fileData,
+		})
+	}
+	return result, nil
+}
+
+func fetchTXTData(ctx context.Context, params *plugin.RetrieveDataParams) (plugin.Data, diagnostics.Diag) {
+
+	glob := params.Args.GetAttr("glob")
+	path := params.Args.GetAttr("path")
+
+	if !(path.IsNull() || path.AsString() == "") {
+		slog.Debug("Reading a file from the path", "path", path.AsString())
+		data, err := readTXTFile(path.AsString())
+		if err != nil {
+			slog.Error(
+				"Error while reading a file",
+				slog.String("path", path.AsString()),
+				slog.Any("error", err),
+			)
+			return nil, diagnostics.Diag{{
+				Severity: hcl.DiagError,
+				Summary:  "Failed to read a file",
+				Detail:   err.Error(),
+			}}
+		}
+		return data, nil
+	} else if !glob.IsNull() && glob.AsString() != "" {
+		slog.Debug("Reading the files that match the glob pattern", "glob", glob.AsString())
+		data, err := readTXTFiles(ctx, glob.AsString())
+		if err != nil {
+			slog.Error(
+				"Error while reading the files",
+				slog.String("glob", glob.AsString()),
+				slog.Any("error", err),
+			)
+			return nil, diagnostics.Diag{{
+				Severity: hcl.DiagError,
+				Summary:  "Failed to read the files",
+				Detail:   err.Error(),
+			}}
+		}
+		return data, nil
+	}
+	slog.Error("Either \"glob\" value or \"path\" value must be provided")
+	return nil, diagnostics.Diag{{
+		Severity: hcl.DiagError,
+		Summary:  "Failed to parse provided arguments",
+		Detail:   "Either \"glob\" value or \"path\" value must be provided",
+	}}
 }

--- a/internal/builtin/data_txt_test.go
+++ b/internal/builtin/data_txt_test.go
@@ -2,14 +2,16 @@ package builtin
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 
-	"github.com/hashicorp/hcl/v2"
 	"github.com/stretchr/testify/assert"
-	"github.com/zclconf/go-cty/cty"
 
 	"github.com/blackstork-io/fabric/pkg/diagnostics"
+	"github.com/blackstork-io/fabric/pkg/diagnostics/diagtest"
 	"github.com/blackstork-io/fabric/plugin"
+	"github.com/blackstork-io/fabric/plugin/plugintest"
 )
 
 func Test_makeTXTDataSchema(t *testing.T) {
@@ -20,48 +22,65 @@ func Test_makeTXTDataSchema(t *testing.T) {
 }
 
 func Test_fetchTXTData(t *testing.T) {
-	type result struct {
-		Data  plugin.Data
-		Diags diagnostics.Diag
-	}
 	tt := []struct {
-		name     string
-		path     string
-		expected result
+		name          string
+		path          string
+		glob          string
+		expectedData  plugin.Data
+		expectedDiags diagtest.Asserts
 	}{
 		{
-			name: "valid_path",
-			path: "testdata/txt/data.txt",
-			expected: result{
-				Data: plugin.StringData("data_content"),
+			name:         "valid_path",
+			path:         "testdata/txt/data.txt",
+			expectedData: plugin.StringData("data_content"),
+		},
+		{
+			name: "with_glob_matches",
+			glob: "testdata/txt/dat*.txt",
+			expectedData: plugin.ListData{
+				plugin.MapData{
+					"file_name": plugin.StringData("data.txt"),
+					"file_path": plugin.StringData("testdata/txt/data.txt"),
+					"content":   plugin.StringData("data_content"),
+				},
 			},
 		},
 		{
-			name: "empty_path",
-			expected: result{
-				Diags: diagnostics.Diag{{
-					Severity: hcl.DiagError,
-					Summary:  "Failed to parse arguments",
-					Detail:   "path is required",
-				}},
-			},
+			name: "no_path_no_glob",
+			expectedDiags: diagtest.Asserts{{
+				diagtest.IsError,
+				diagtest.SummaryEquals("Failed to parse provided arguments"),
+				diagtest.DetailEquals("Either \"glob\" value or \"path\" value must be provided"),
+			}},
+		},
+		{
+			name:         "no_glob_matches",
+			glob:         "testdata/txt/does-not-exist*.txt",
+			expectedData: plugin.ListData{},
 		},
 		{
 			name: "invalid_path",
 			path: "testdata/txt/does_not_exist.txt",
-			expected: result{
-				Diags: diagnostics.Diag{{
-					Severity: hcl.DiagError,
-					Summary:  "Failed to open txt file",
-					Detail:   "open testdata/txt/does_not_exist.txt: no such file or directory",
-				}},
-			},
+			expectedDiags: diagtest.Asserts{{
+				diagtest.IsError,
+				diagtest.SummaryEquals("Failed to read a file"),
+				diagtest.DetailEquals("<nil>: Failed to open a file; open testdata/txt/does_not_exist.txt: no such file or directory"),
+			}},
 		},
 		{
-			name: "empty_file",
-			path: "testdata/txt/empty.txt",
-			expected: result{
-				Data: plugin.StringData(""),
+			name:         "empty_file_with_path",
+			path:         "testdata/txt/empty.txt",
+			expectedData: plugin.StringData(""),
+		},
+		{
+			name: "empty_file_with_glob",
+			glob: "testdata/txt/empt*.txt",
+			expectedData: plugin.ListData{
+				plugin.MapData{
+					"file_name": plugin.StringData("empty.txt"),
+					"file_path": plugin.StringData("testdata/txt/empty.txt"),
+					"content":   plugin.StringData(""),
+				},
 			},
 		},
 	}
@@ -73,12 +92,31 @@ func Test_fetchTXTData(t *testing.T) {
 					"txt": makeTXTDataSource(),
 				},
 			}
-			data, diags := p.RetrieveData(context.Background(), "txt", &plugin.RetrieveDataParams{
-				Args: cty.ObjectVal(map[string]cty.Value{
-					"path": cty.StringVal(tc.path),
-				}),
-			})
-			assert.Equal(t, tc.expected, result{data, diags})
+
+			args := make([]string, 0)
+			if tc.path != "" {
+				args = append(args, fmt.Sprintf("path = %q", tc.path))
+			}
+			if tc.glob != "" {
+				args = append(args, fmt.Sprintf("glob = %q", tc.glob))
+			}
+			argsBody := strings.Join(args, ",")
+
+			var diags diagnostics.Diag
+
+			argVal, diag := plugintest.Decode(t, p.DataSources["txt"].Args, argsBody)
+			diags.Extend(diag)
+
+			var data plugin.Data
+			if !diags.HasErrors() {
+				ctx := context.Background()
+				var dgs diagnostics.Diag
+				data, dgs = p.RetrieveData(ctx, "txt", &plugin.RetrieveDataParams{Args: argVal})
+				diags.Extend(dgs)
+			}
+			assert.Equal(t, tc.expectedData, data)
+			tc.expectedDiags.AssertMatch(t, diags, nil)
+
 		})
 	}
 }


### PR DESCRIPTION
## What was changed

- `txt`, `csv` and `json` data sources were adjusted to support both `path` and `glob` parameters
- the unit tests were updated

Fixes https://github.com/blackstork-io/fabric/issues/176