### PR TITLE
feat: Support partial path in `data` command

### DIFF
--- a/cmd/data.go
+++ b/cmd/data.go
@@ -15,14 +15,17 @@ import (
 func init() {
 	rootCmd.AddCommand(dataCmd)
 	dataCmd.SetUsageTemplate(UsageTemplate(
-		[2]string{"TARGET", "a path to the data block to be executed. Data block must be inside of a document, so the path would look lile 'document.<doc-name>.data.<plugin-name>.<data-name>'"},
+		[2]string{
+			"PATH",
+			"a path to data blocks to be executed. The path format is 'document.<doc-name>.data[.<plugin-name>[.<data-name>]]'.",
+		},
 	))
 }
 
 var dataCmd = &cobra.Command{
 	Use:   "data TARGET",
-	Short: "Execute a single data block",
-	Long:  `Execute the data block and print out prettified JSON to stdout`,
+	Short: "Execute the data blocks that match the path",
+	Long:  `Execute the data blocks that match the path and print out prettified JSON to stdout`,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		ctx := cmd.Context()

--- a/docs/plugins/plugins.json
+++ b/docs/plugins/plugins.json
@@ -28,17 +28,91 @@
     "shortname": "builtin",
     "resources": [
       {
-        "name": "blockquote",
+        "name": "sleep",
+        "type": "content-provider",
+        "arguments": [
+          "duration"
+        ]
+      },
+      {
+        "name": "table",
+        "type": "content-provider",
+        "arguments": [
+          "columns",
+          "rows"
+        ]
+      },
+      {
+        "name": "sleep",
+        "type": "data-source",
+        "arguments": [
+          "duration"
+        ]
+      },
+      {
+        "name": "image",
+        "type": "content-provider",
+        "arguments": [
+          "alt",
+          "src"
+        ]
+      },
+      {
+        "name": "hub",
+        "type": "publisher",
+        "config_params": [
+          "api_token",
+          "api_url"
+        ],
+        "arguments": [
+          "title"
+        ]
+      },
+      {
+        "name": "rss",
+        "type": "data-source",
+        "arguments": [
+          "fill_in_content",
+          "items_after",
+          "items_before",
+          "max_items_to_fill",
+          "url",
+          "use_browser_user_agent"
+        ]
+      },
+      {
+        "name": "json",
+        "type": "data-source",
+        "arguments": [
+          "glob",
+          "path"
+        ]
+      },
+      {
+        "name": "text",
         "type": "content-provider",
         "arguments": [
           "value"
         ]
       },
       {
-        "name": "code",
+        "name": "http",
+        "type": "data-source",
+        "arguments": [
+          "body",
+          "headers",
+          "insecure",
+          "method",
+          "timeout",
+          "url"
+        ]
+      },
+      {
+        "name": "title",
         "type": "content-provider",
         "arguments": [
-          "language",
+          "absolute_size",
+          "relative_size",
           "value"
         ]
       },
@@ -62,108 +136,10 @@
         ]
       },
       {
-        "name": "http",
-        "type": "data-source",
-        "arguments": [
-          "body",
-          "headers",
-          "insecure",
-          "method",
-          "timeout",
-          "url"
-        ]
-      },
-      {
-        "name": "hub",
-        "type": "publisher",
-        "config_params": [
-          "api_token",
-          "api_url"
-        ],
-        "arguments": [
-          "title"
-        ]
-      },
-      {
-        "name": "image",
-        "type": "content-provider",
-        "arguments": [
-          "alt",
-          "src"
-        ]
-      },
-      {
-        "name": "json",
-        "type": "data-source",
-        "arguments": [
-          "glob",
-          "path"
-        ]
-      },
-      {
-        "name": "list",
-        "type": "content-provider",
-        "arguments": [
-          "format",
-          "item_template",
-          "items"
-        ]
-      },
-      {
         "name": "local_file",
         "type": "publisher",
         "arguments": [
           "path"
-        ]
-      },
-      {
-        "name": "rss",
-        "type": "data-source",
-        "arguments": [
-          "fill_in_content",
-          "items_after",
-          "items_before",
-          "max_items_to_fill",
-          "url",
-          "use_browser_user_agent"
-        ]
-      },
-      {
-        "name": "sleep",
-        "type": "content-provider",
-        "arguments": [
-          "duration"
-        ]
-      },
-      {
-        "name": "sleep",
-        "type": "data-source",
-        "arguments": [
-          "duration"
-        ]
-      },
-      {
-        "name": "table",
-        "type": "content-provider",
-        "arguments": [
-          "columns",
-          "rows"
-        ]
-      },
-      {
-        "name": "text",
-        "type": "content-provider",
-        "arguments": [
-          "value"
-        ]
-      },
-      {
-        "name": "title",
-        "type": "content-provider",
-        "arguments": [
-          "absolute_size",
-          "relative_size",
-          "value"
         ]
       },
       {
@@ -177,7 +153,31 @@
         ]
       },
       {
-        "name": "txt",
+        "name": "code",
+        "type": "content-provider",
+        "arguments": [
+          "language",
+          "value"
+        ]
+      },
+      {
+        "name": "blockquote",
+        "type": "content-provider",
+        "arguments": [
+          "value"
+        ]
+      },
+      {
+        "name": "list",
+        "type": "content-provider",
+        "arguments": [
+          "format",
+          "item_template",
+          "items"
+        ]
+      },
+      {
+        "name": "yaml",
         "type": "data-source",
         "arguments": [
           "glob",
@@ -185,7 +185,7 @@
         ]
       },
       {
-        "name": "yaml",
+        "name": "txt",
         "type": "data-source",
         "arguments": [
           "glob",
@@ -227,7 +227,7 @@
         ]
       },
       {
-        "name": "falcon_discover_host_details",
+        "name": "falcon_vulnerabilities",
         "type": "data-source",
         "config_params": [
           "client_cloud",
@@ -237,7 +237,8 @@
         ],
         "arguments": [
           "filter",
-          "limit"
+          "limit",
+          "sort"
         ]
       },
       {
@@ -256,7 +257,7 @@
         ]
       },
       {
-        "name": "falcon_vulnerabilities",
+        "name": "falcon_discover_host_details",
         "type": "data-source",
         "config_params": [
           "client_cloud",
@@ -266,8 +267,7 @@
         ],
         "arguments": [
           "filter",
-          "limit",
-          "sort"
+          "limit"
         ]
       }
     ]
@@ -277,6 +277,30 @@
     "version": "v0.4.2",
     "shortname": "elastic",
     "resources": [
+      {
+        "name": "elasticsearch",
+        "type": "data-source",
+        "config_params": [
+          "api_key",
+          "api_key_str",
+          "base_url",
+          "basic_auth_password",
+          "basic_auth_username",
+          "bearer_auth",
+          "ca_certs",
+          "cloud_id"
+        ],
+        "arguments": [
+          "aggs",
+          "fields",
+          "id",
+          "index",
+          "only_hits",
+          "query",
+          "query_string",
+          "size"
+        ]
+      },
       {
         "name": "elastic_security_cases",
         "type": "data-source",
@@ -302,30 +326,6 @@
           "tags",
           "to"
         ]
-      },
-      {
-        "name": "elasticsearch",
-        "type": "data-source",
-        "config_params": [
-          "api_key",
-          "api_key_str",
-          "base_url",
-          "basic_auth_password",
-          "basic_auth_username",
-          "bearer_auth",
-          "ca_certs",
-          "cloud_id"
-        ],
-        "arguments": [
-          "aggs",
-          "fields",
-          "id",
-          "index",
-          "only_hits",
-          "query",
-          "query_string",
-          "size"
-        ]
       }
     ]
   },
@@ -334,19 +334,6 @@
     "version": "v0.4.2",
     "shortname": "github",
     "resources": [
-      {
-        "name": "github_gist",
-        "type": "publisher",
-        "config_params": [
-          "github_token"
-        ],
-        "arguments": [
-          "description",
-          "filename",
-          "gist_id",
-          "make_public"
-        ]
-      },
       {
         "name": "github_issues",
         "type": "data-source",
@@ -365,6 +352,19 @@
           "since",
           "sort",
           "state"
+        ]
+      },
+      {
+        "name": "github_gist",
+        "type": "publisher",
+        "config_params": [
+          "github_token"
+        ],
+        "arguments": [
+          "description",
+          "filename",
+          "gist_id",
+          "make_public"
         ]
       }
     ]
@@ -456,6 +456,27 @@
     "shortname": "iris",
     "resources": [
       {
+        "name": "iris_cases",
+        "type": "data-source",
+        "config_params": [
+          "api_key",
+          "api_url",
+          "insecure"
+        ],
+        "arguments": [
+          "case_ids",
+          "customer_id",
+          "end_open_date",
+          "owner_id",
+          "severity_id",
+          "size",
+          "soc_id",
+          "sort",
+          "start_open_date",
+          "state_id"
+        ]
+      },
+      {
         "name": "iris_alerts",
         "type": "data-source",
         "config_params": [
@@ -477,27 +498,6 @@
           "sort",
           "status_id",
           "tags"
-        ]
-      },
-      {
-        "name": "iris_cases",
-        "type": "data-source",
-        "config_params": [
-          "api_key",
-          "api_url",
-          "insecure"
-        ],
-        "arguments": [
-          "case_ids",
-          "customer_id",
-          "end_open_date",
-          "owner_id",
-          "severity_id",
-          "size",
-          "soc_id",
-          "sort",
-          "start_open_date",
-          "state_id"
         ]
       }
     ]
@@ -522,6 +522,23 @@
           "prompt",
           "temperature",
           "top_p"
+        ]
+      },
+      {
+        "name": "microsoft_sentinel_incidents",
+        "type": "data-source",
+        "config_params": [
+          "client_id",
+          "client_secret",
+          "resource_group_name",
+          "subscription_id",
+          "tenant_id",
+          "workspace_name"
+        ],
+        "arguments": [
+          "filter",
+          "order_by",
+          "size"
         ]
       },
       {
@@ -575,23 +592,6 @@
         "arguments": [
           "query"
         ]
-      },
-      {
-        "name": "microsoft_sentinel_incidents",
-        "type": "data-source",
-        "config_params": [
-          "client_id",
-          "client_secret",
-          "resource_group_name",
-          "subscription_id",
-          "tenant_id",
-          "workspace_name"
-        ],
-        "arguments": [
-          "filter",
-          "order_by",
-          "size"
-        ]
       }
     ]
   },
@@ -600,21 +600,6 @@
     "version": "v0.4.2",
     "shortname": "misp",
     "resources": [
-      {
-        "name": "misp_event_reports",
-        "type": "publisher",
-        "config_params": [
-          "api_key",
-          "base_url",
-          "skip_ssl"
-        ],
-        "arguments": [
-          "distribution",
-          "event_id",
-          "name",
-          "sharing_group_id"
-        ]
-      },
       {
         "name": "misp_events",
         "type": "data-source",
@@ -642,6 +627,21 @@
           "uuid",
           "value",
           "with_attachments"
+        ]
+      },
+      {
+        "name": "misp_event_reports",
+        "type": "publisher",
+        "config_params": [
+          "api_key",
+          "base_url",
+          "skip_ssl"
+        ],
+        "arguments": [
+          "distribution",
+          "event_id",
+          "name",
+          "sharing_group_id"
         ]
       }
     ]

--- a/docs/plugins/plugins.json
+++ b/docs/plugins/plugins.json
@@ -28,91 +28,17 @@
     "shortname": "builtin",
     "resources": [
       {
-        "name": "sleep",
-        "type": "content-provider",
-        "arguments": [
-          "duration"
-        ]
-      },
-      {
-        "name": "table",
-        "type": "content-provider",
-        "arguments": [
-          "columns",
-          "rows"
-        ]
-      },
-      {
-        "name": "sleep",
-        "type": "data-source",
-        "arguments": [
-          "duration"
-        ]
-      },
-      {
-        "name": "image",
-        "type": "content-provider",
-        "arguments": [
-          "alt",
-          "src"
-        ]
-      },
-      {
-        "name": "hub",
-        "type": "publisher",
-        "config_params": [
-          "api_token",
-          "api_url"
-        ],
-        "arguments": [
-          "title"
-        ]
-      },
-      {
-        "name": "rss",
-        "type": "data-source",
-        "arguments": [
-          "fill_in_content",
-          "items_after",
-          "items_before",
-          "max_items_to_fill",
-          "url",
-          "use_browser_user_agent"
-        ]
-      },
-      {
-        "name": "json",
-        "type": "data-source",
-        "arguments": [
-          "glob",
-          "path"
-        ]
-      },
-      {
-        "name": "text",
+        "name": "blockquote",
         "type": "content-provider",
         "arguments": [
           "value"
         ]
       },
       {
-        "name": "http",
-        "type": "data-source",
-        "arguments": [
-          "body",
-          "headers",
-          "insecure",
-          "method",
-          "timeout",
-          "url"
-        ]
-      },
-      {
-        "name": "title",
+        "name": "code",
         "type": "content-provider",
         "arguments": [
-          "absolute_size",
-          "relative_size",
+          "language",
           "value"
         ]
       },
@@ -136,10 +62,108 @@
         ]
       },
       {
+        "name": "http",
+        "type": "data-source",
+        "arguments": [
+          "body",
+          "headers",
+          "insecure",
+          "method",
+          "timeout",
+          "url"
+        ]
+      },
+      {
+        "name": "hub",
+        "type": "publisher",
+        "config_params": [
+          "api_token",
+          "api_url"
+        ],
+        "arguments": [
+          "title"
+        ]
+      },
+      {
+        "name": "image",
+        "type": "content-provider",
+        "arguments": [
+          "alt",
+          "src"
+        ]
+      },
+      {
+        "name": "json",
+        "type": "data-source",
+        "arguments": [
+          "glob",
+          "path"
+        ]
+      },
+      {
+        "name": "list",
+        "type": "content-provider",
+        "arguments": [
+          "format",
+          "item_template",
+          "items"
+        ]
+      },
+      {
         "name": "local_file",
         "type": "publisher",
         "arguments": [
           "path"
+        ]
+      },
+      {
+        "name": "rss",
+        "type": "data-source",
+        "arguments": [
+          "fill_in_content",
+          "items_after",
+          "items_before",
+          "max_items_to_fill",
+          "url",
+          "use_browser_user_agent"
+        ]
+      },
+      {
+        "name": "sleep",
+        "type": "content-provider",
+        "arguments": [
+          "duration"
+        ]
+      },
+      {
+        "name": "sleep",
+        "type": "data-source",
+        "arguments": [
+          "duration"
+        ]
+      },
+      {
+        "name": "table",
+        "type": "content-provider",
+        "arguments": [
+          "columns",
+          "rows"
+        ]
+      },
+      {
+        "name": "text",
+        "type": "content-provider",
+        "arguments": [
+          "value"
+        ]
+      },
+      {
+        "name": "title",
+        "type": "content-provider",
+        "arguments": [
+          "absolute_size",
+          "relative_size",
+          "value"
         ]
       },
       {
@@ -153,31 +177,7 @@
         ]
       },
       {
-        "name": "code",
-        "type": "content-provider",
-        "arguments": [
-          "language",
-          "value"
-        ]
-      },
-      {
-        "name": "blockquote",
-        "type": "content-provider",
-        "arguments": [
-          "value"
-        ]
-      },
-      {
-        "name": "list",
-        "type": "content-provider",
-        "arguments": [
-          "format",
-          "item_template",
-          "items"
-        ]
-      },
-      {
-        "name": "yaml",
+        "name": "txt",
         "type": "data-source",
         "arguments": [
           "glob",
@@ -185,7 +185,7 @@
         ]
       },
       {
-        "name": "txt",
+        "name": "yaml",
         "type": "data-source",
         "arguments": [
           "glob",
@@ -227,7 +227,7 @@
         ]
       },
       {
-        "name": "falcon_vulnerabilities",
+        "name": "falcon_discover_host_details",
         "type": "data-source",
         "config_params": [
           "client_cloud",
@@ -237,8 +237,7 @@
         ],
         "arguments": [
           "filter",
-          "limit",
-          "sort"
+          "limit"
         ]
       },
       {
@@ -257,7 +256,7 @@
         ]
       },
       {
-        "name": "falcon_discover_host_details",
+        "name": "falcon_vulnerabilities",
         "type": "data-source",
         "config_params": [
           "client_cloud",
@@ -267,7 +266,8 @@
         ],
         "arguments": [
           "filter",
-          "limit"
+          "limit",
+          "sort"
         ]
       }
     ]
@@ -277,30 +277,6 @@
     "version": "v0.4.2",
     "shortname": "elastic",
     "resources": [
-      {
-        "name": "elasticsearch",
-        "type": "data-source",
-        "config_params": [
-          "api_key",
-          "api_key_str",
-          "base_url",
-          "basic_auth_password",
-          "basic_auth_username",
-          "bearer_auth",
-          "ca_certs",
-          "cloud_id"
-        ],
-        "arguments": [
-          "aggs",
-          "fields",
-          "id",
-          "index",
-          "only_hits",
-          "query",
-          "query_string",
-          "size"
-        ]
-      },
       {
         "name": "elastic_security_cases",
         "type": "data-source",
@@ -326,6 +302,30 @@
           "tags",
           "to"
         ]
+      },
+      {
+        "name": "elasticsearch",
+        "type": "data-source",
+        "config_params": [
+          "api_key",
+          "api_key_str",
+          "base_url",
+          "basic_auth_password",
+          "basic_auth_username",
+          "bearer_auth",
+          "ca_certs",
+          "cloud_id"
+        ],
+        "arguments": [
+          "aggs",
+          "fields",
+          "id",
+          "index",
+          "only_hits",
+          "query",
+          "query_string",
+          "size"
+        ]
       }
     ]
   },
@@ -334,6 +334,19 @@
     "version": "v0.4.2",
     "shortname": "github",
     "resources": [
+      {
+        "name": "github_gist",
+        "type": "publisher",
+        "config_params": [
+          "github_token"
+        ],
+        "arguments": [
+          "description",
+          "filename",
+          "gist_id",
+          "make_public"
+        ]
+      },
       {
         "name": "github_issues",
         "type": "data-source",
@@ -352,19 +365,6 @@
           "since",
           "sort",
           "state"
-        ]
-      },
-      {
-        "name": "github_gist",
-        "type": "publisher",
-        "config_params": [
-          "github_token"
-        ],
-        "arguments": [
-          "description",
-          "filename",
-          "gist_id",
-          "make_public"
         ]
       }
     ]
@@ -456,27 +456,6 @@
     "shortname": "iris",
     "resources": [
       {
-        "name": "iris_cases",
-        "type": "data-source",
-        "config_params": [
-          "api_key",
-          "api_url",
-          "insecure"
-        ],
-        "arguments": [
-          "case_ids",
-          "customer_id",
-          "end_open_date",
-          "owner_id",
-          "severity_id",
-          "size",
-          "soc_id",
-          "sort",
-          "start_open_date",
-          "state_id"
-        ]
-      },
-      {
         "name": "iris_alerts",
         "type": "data-source",
         "config_params": [
@@ -498,6 +477,27 @@
           "sort",
           "status_id",
           "tags"
+        ]
+      },
+      {
+        "name": "iris_cases",
+        "type": "data-source",
+        "config_params": [
+          "api_key",
+          "api_url",
+          "insecure"
+        ],
+        "arguments": [
+          "case_ids",
+          "customer_id",
+          "end_open_date",
+          "owner_id",
+          "severity_id",
+          "size",
+          "soc_id",
+          "sort",
+          "start_open_date",
+          "state_id"
         ]
       }
     ]
@@ -522,23 +522,6 @@
           "prompt",
           "temperature",
           "top_p"
-        ]
-      },
-      {
-        "name": "microsoft_sentinel_incidents",
-        "type": "data-source",
-        "config_params": [
-          "client_id",
-          "client_secret",
-          "resource_group_name",
-          "subscription_id",
-          "tenant_id",
-          "workspace_name"
-        ],
-        "arguments": [
-          "filter",
-          "order_by",
-          "size"
         ]
       },
       {
@@ -592,6 +575,23 @@
         "arguments": [
           "query"
         ]
+      },
+      {
+        "name": "microsoft_sentinel_incidents",
+        "type": "data-source",
+        "config_params": [
+          "client_id",
+          "client_secret",
+          "resource_group_name",
+          "subscription_id",
+          "tenant_id",
+          "workspace_name"
+        ],
+        "arguments": [
+          "filter",
+          "order_by",
+          "size"
+        ]
       }
     ]
   },
@@ -600,6 +600,21 @@
     "version": "v0.4.2",
     "shortname": "misp",
     "resources": [
+      {
+        "name": "misp_event_reports",
+        "type": "publisher",
+        "config_params": [
+          "api_key",
+          "base_url",
+          "skip_ssl"
+        ],
+        "arguments": [
+          "distribution",
+          "event_id",
+          "name",
+          "sharing_group_id"
+        ]
+      },
       {
         "name": "misp_events",
         "type": "data-source",
@@ -627,21 +642,6 @@
           "uuid",
           "value",
           "with_attachments"
-        ]
-      },
-      {
-        "name": "misp_event_reports",
-        "type": "publisher",
-        "config_params": [
-          "api_key",
-          "base_url",
-          "skip_ssl"
-        ],
-        "arguments": [
-          "distribution",
-          "event_id",
-          "name",
-          "sharing_group_id"
         ]
       }
     ]

--- a/docs/plugins/plugins.json
+++ b/docs/plugins/plugins.json
@@ -130,14 +130,14 @@
       },
       {
         "name": "sleep",
-        "type": "data-source",
+        "type": "content-provider",
         "arguments": [
           "duration"
         ]
       },
       {
         "name": "sleep",
-        "type": "content-provider",
+        "type": "data-source",
         "arguments": [
           "duration"
         ]

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -325,7 +325,6 @@ func (e *Engine) loadDocumentData(
 	doc string,
 	path []string,
 ) (_ plugindata.Data, diags diagnostics.Diag) {
-
 	pathStr := strings.Join(path, ".")
 
 	ctx, span := e.tracer.Start(ctx, "Engine.loadDocumentData", trace.WithAttributes(

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -23,15 +23,59 @@ func TestEngineFetchData(t *testing.T) {
 					path = "testdata/a.json"
 				}
 
+				data json "test2" {
+					path = "testdata/a.json"
+				}
+
 				content text {
-					text = "hello"
+					value = "hello"
 				}
 			}
 			`,
 		},
 		"document.hello.data.json.test",
 		plugindata.Map{
-			"property_for": plugindata.String("a.json"),
+			"data": plugindata.Map{
+				"json": plugindata.Map{
+					"test": plugindata.Map{
+						"property_for": plugindata.String("a.json"),
+					},
+				},
+			},
+		},
+		[][]diagtest.Assert{},
+	)
+	fetchDataTest(
+		t, "Basic",
+		[]string{
+			`
+			document "hello" {
+				data json "test" {
+					path = "testdata/a.json"
+				}
+
+				data json "test2" {
+					path = "testdata/a.json"
+				}
+
+				content text {
+					value = "hello"
+				}
+			}
+			`,
+		},
+		"document.hello.data.json",
+		plugindata.Map{
+			"data": plugindata.Map{
+				"json": plugindata.Map{
+					"test": plugindata.Map{
+						"property_for": plugindata.String("a.json"),
+					},
+					"test2": plugindata.Map{
+						"property_for": plugindata.String("a.json"),
+					},
+				},
+			},
 		},
 		[][]diagtest.Assert{},
 	)
@@ -44,7 +88,7 @@ func TestEngineFetchData(t *testing.T) {
 			}
 			document "hello" {
 				content text {
-					text = "hello"
+					value = "hello"
 				}
 			}
 			`,

--- a/eval/document.go
+++ b/eval/document.go
@@ -28,6 +28,11 @@ func (doc *Document) FetchData(ctx context.Context) (plugindata.Data, diagnostic
 	return evaluator.Execute()
 }
 
+func (doc *Document) FetchDataWithPath(ctx context.Context, path []string) (plugindata.Data, diagnostics.Diag) {
+	evaluator := makeAsyncDataEvaluatorWithPath(ctx, doc, path, slog.Default())
+	return evaluator.Execute()
+}
+
 func filterChildrenByTags(children []*Content, requiredTags []string) []*Content {
 	return slices.DeleteFunc(children, func(child *Content) bool {
 		switch {

--- a/eval/evaluator.go
+++ b/eval/evaluator.go
@@ -29,8 +29,12 @@ func makeAsyncDataEvaluator(ctx context.Context, doc *Document, logger *slog.Log
 	}
 }
 
-func makeAsyncDataEvaluatorWithPath(ctx context.Context, doc *Document, path []string, logger *slog.Logger) *asyncDataEvaluator {
-
+func makeAsyncDataEvaluatorWithPath(
+	ctx context.Context,
+	doc *Document,
+	path []string,
+	logger *slog.Logger,
+) *asyncDataEvaluator {
 	var dataSourceName string
 	if len(path) > 0 {
 		dataSourceName = path[0]
@@ -64,7 +68,6 @@ func makeAsyncDataEvaluatorWithPath(ctx context.Context, doc *Document, path []s
 	}
 }
 
-
 type asyncDataEvalResult struct {
 	pluginName string
 	blockName  string
@@ -78,7 +81,11 @@ func (doc *asyncDataEvaluator) Execute() (plugindata.Data, diagnostics.Diag) {
 	resultch := make(chan *asyncDataEvalResult, len(doc.blocks))
 	for _, block := range doc.blocks {
 		go func(block *PluginDataAction, resultch chan<- *asyncDataEvalResult) {
-			doc.logger.DebugContext(doc.ctx, "Fetching data for block", "plugin", block.PluginName, "block", block.BlockName)
+			doc.logger.DebugContext(
+				doc.ctx, "Fetching data for block",
+				"plugin", block.PluginName,
+				"block", block.BlockName,
+			)
 			data, diags := block.FetchData(doc.ctx)
 			resultch <- &asyncDataEvalResult{
 				pluginName: block.PluginName,
@@ -110,7 +117,11 @@ func (doc *asyncDataEvaluator) Execute() (plugindata.Data, diagnostics.Diag) {
 				return nil, diagnostics.Diag{{
 					Severity: hcl.DiagError,
 					Summary:  "Conflicting data",
-					Detail:   fmt.Sprintf("Different type data block with the same name already exists at plugin '%s' and block '%s'", res.pluginName, res.blockName),
+					Detail: fmt.Sprintf(
+						"Different type data block with the same name already exists at plugin '%s' and block '%s'",
+						res.pluginName,
+						res.blockName,
+					),
 				}}
 			}
 		} else {
@@ -187,7 +198,10 @@ type asyncContentEvaluator struct {
 	rootNode  *plugin.ContentSection
 }
 
-func (ace *asyncContentEvaluator) executeGroup(dataCtx plugindata.Map, invokeOrder plugin.InvocationOrder) diagnostics.Diag {
+func (ace *asyncContentEvaluator) executeGroup(
+	dataCtx plugindata.Map,
+	invokeOrder plugin.InvocationOrder,
+) diagnostics.Diag {
 	list, ok := ace.invokeMap[invokeOrder]
 	if !ok || len(list) == 0 {
 		return nil
@@ -231,7 +245,11 @@ func (ace *asyncContentEvaluator) Execute(dataCtx plugindata.Map) (*plugin.Conte
 	return ace.rootNode, diags
 }
 
-func makeAsyncContentEvaluator(ctx context.Context, content []*Content, dataCtx plugindata.Map) (*asyncContentEvaluator, diagnostics.Diag) {
+func makeAsyncContentEvaluator(
+	ctx context.Context,
+	content []*Content,
+	dataCtx plugindata.Map,
+) (*asyncContentEvaluator, diagnostics.Diag) {
 	namedMap := make(map[string]*asyncContent)
 	invokeMap := make(map[plugin.InvocationOrder][]*asyncContent)
 	rootNode := plugin.NewSection(0)
@@ -272,7 +290,11 @@ func assignAsyncContent(
 					return diagnostics.Diag{{
 						Severity: hcl.DiagError,
 						Summary:  "Dependency not found",
-						Detail:   fmt.Sprintf("Content block '%s' depends on '%s' but it's not found", c.Plugin.BlockName, depName),
+						Detail: fmt.Sprintf(
+							"Content block '%s' depends on '%s' but it's not found",
+							c.Plugin.BlockName,
+							depName,
+						),
 					}}
 				}
 

--- a/internal/builtin/data_rss.go
+++ b/internal/builtin/data_rss.go
@@ -280,7 +280,8 @@ func fetchRSSData(ctx context.Context, params *plugin.RetrieveDataParams) (plugi
 	ctx, cancel := context.WithTimeout(ctx, defaultRequestTimeout)
 	defer cancel()
 
-	log.InfoContext(ctx, "Downloading the feed", "feed_url", url)
+	log = log.With("feed_url", url)
+	log.InfoContext(ctx, "Downloading the feed")
 
 	feed, err := fp.ParseURLWithContext(url, ctx)
 	if err != nil {

--- a/plugin/pluginapi/v1/client.go
+++ b/plugin/pluginapi/v1/client.go
@@ -33,8 +33,8 @@ func NewClient(name, binaryPath string, logger *slog.Logger) (p *plugin.Schema, 
 		),
 		GRPCDialOptions: []grpc.DialOption{
 			grpc.WithDefaultCallOptions(
-				grpc.MaxCallRecvMsgSize(defaultMsgSize),
-				grpc.MaxCallSendMsgSize(defaultMsgSize),
+				grpc.MaxCallRecvMsgSize(maxMsgSize),
+				grpc.MaxCallSendMsgSize(maxMsgSize),
 			),
 		},
 	})

--- a/plugin/pluginapi/v1/plugin.go
+++ b/plugin/pluginapi/v1/plugin.go
@@ -15,7 +15,7 @@ import (
 	"github.com/blackstork-io/fabric/plugin/plugindata"
 )
 
-var defaultMsgSize = 1024 * 1024 * 20
+var maxMsgSize = 1024 * 1024 * 100 // 100MB
 
 var handshake = goplugin.HandshakeConfig{
 	ProtocolVersion:  1,
@@ -69,8 +69,8 @@ func (p *grpcPlugin) GRPCClient(ctx context.Context, broker *goplugin.GRPCBroker
 
 func (p *grpcPlugin) callOptions() []grpc.CallOption {
 	return []grpc.CallOption{
-		grpc.MaxCallRecvMsgSize(defaultMsgSize),
-		grpc.MaxCallSendMsgSize(defaultMsgSize),
+		grpc.MaxCallRecvMsgSize(maxMsgSize),
+		grpc.MaxCallSendMsgSize(maxMsgSize),
 	}
 }
 

--- a/plugin/pluginapi/v1/server.go
+++ b/plugin/pluginapi/v1/server.go
@@ -19,7 +19,7 @@ func Serve(schema *plugin.Schema) {
 			schema.Name: &grpcPlugin{schema: schema},
 		},
 		GRPCServer: func(opts []grpc.ServerOption) *grpc.Server {
-			opts = append(opts, grpc.MaxRecvMsgSize(defaultMsgSize))
+			opts = append(opts, grpc.MaxRecvMsgSize(maxMsgSize))
 			return grpc.NewServer(opts...)
 		},
 		Logger: loggerForGoplugin(),

--- a/tools/docgen/main.go
+++ b/tools/docgen/main.go
@@ -83,7 +83,7 @@ func generateDataSourceDocs(log *slog.Logger, p *plugin.Schema, outputDir string
 	dataSourcesDir := filepath.Join(outputDir, "data-sources")
 
 	// Create a directory for plugin's data sources if it doesn't exist
-	err := os.MkdirAll(dataSourcesDir, 0o766)
+	err := os.MkdirAll(dataSourcesDir, 0o750)
 	if err != nil {
 		log.Error("Can't create a directory", "path", dataSourcesDir)
 		panic(err)
@@ -107,7 +107,7 @@ func generateContentProviderDocs(log *slog.Logger, p *plugin.Schema, outputDir s
 	contentProvidersDir := filepath.Join(outputDir, "content-providers")
 
 	// Create a directory for plugin's content providers if it doesn't exist
-	err := os.MkdirAll(contentProvidersDir, 0o766)
+	err := os.MkdirAll(contentProvidersDir, 0o750)
 	if err != nil {
 		log.Error("Can't create a directory", "path", contentProvidersDir)
 		panic(err)
@@ -132,7 +132,7 @@ func generatePublisherDocs(log *slog.Logger, p *plugin.Schema, outputDir string)
 	publishersDir := filepath.Join(outputDir, "publishers")
 
 	// Create a directory for plugin's publishers if it doesn't exist
-	err := os.MkdirAll(publishersDir, 0o766)
+	err := os.MkdirAll(publishersDir, 0o750)
 	if err != nil {
 		log.Error("Can't create a directory", "path", publishersDir)
 		panic(err)
@@ -225,7 +225,9 @@ func generateMetadataFile(plugins []*plugin.Schema, outputDir string) {
 		}
 
 		sort.Slice(resources, func(i, j int) bool {
-			return resources[i].Name < resources[j].Name
+			a := resources[i]
+			b := resources[j]
+			return a.Name < b.Name && a.Type < b.Type
 		})
 
 		pluginDetails[i] = PluginDetails{
@@ -247,24 +249,34 @@ func generateMetadataFile(plugins []*plugin.Schema, outputDir string) {
 	}
 
 	pluginDetailsPath := filepath.Join(outputDir, "plugins.json")
-	file, err := os.Create(pluginDetailsPath)
+	file, err := os.Create(pluginDetailsPath) //nolint:gosec
 	if err != nil {
 		panic(err)
 	}
 	defer file.Close()
 
-	file.Write(jsonData)
+	_, err = file.Write(jsonData)
+	if err != nil {
+		slog.Error("Can't write create a plugins JSON file", "path", pluginDetailsPath)
+		return
+	}
 
 	slog.Info("Plugin details file generated", "path", pluginDetailsPath)
 }
 
 func main() {
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
 	// parse flags
 	flags := pflag.NewFlagSet("docgen", pflag.ExitOnError)
 	flags.StringVar(&version, "version", "v0.0.0-dev", "version of the build")
 	flags.StringVar(&outputDir, "output", "./dist/docs", "output directory")
-	flags.Parse(os.Args[1:])
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	err := flags.Parse(os.Args[1:])
+	if err != nil {
+		logger.Error("Can't parse provided arguments", "err", err)
+		return
+	}
 	// load all plugins
 	plugins := []*plugin.Schema{
 		builtin.Plugin(version, logger, nil),
@@ -299,7 +311,7 @@ func main() {
 		pluginOutputDir := filepath.Join(outputDir, pluginShortname)
 
 		// Create a plugin directory if it doesn't exist
-		err := os.MkdirAll(pluginOutputDir, 0o766)
+		err := os.MkdirAll(pluginOutputDir, 0o750)
 		if err != nil {
 			log.Error("Can't create a plugin directory", "path", pluginOutputDir)
 			panic(err)
@@ -329,7 +341,7 @@ func main() {
 }
 
 func renderPluginDoc(pluginSchema *plugin.Schema, fp string) error {
-	f, err := os.Create(fp)
+	f, err := os.Create(fp) // nolint: gosec
 	if err != nil {
 		return err
 	}
@@ -338,8 +350,13 @@ func renderPluginDoc(pluginSchema *plugin.Schema, fp string) error {
 	return base.ExecuteTemplate(f, "plugin", pluginSchema)
 }
 
-func renderContentProviderDoc(pluginSchema *plugin.Schema, contentProviderName string, contentProvider *plugin.ContentProvider, fp string) error {
-	f, err := os.Create(fp)
+func renderContentProviderDoc(
+	pluginSchema *plugin.Schema,
+	contentProviderName string,
+	contentProvider *plugin.ContentProvider,
+	fp string,
+) error {
+	f, err := os.Create(fp) // nolint: gosec
 	if err != nil {
 		return err
 	}
@@ -356,8 +373,13 @@ func renderContentProviderDoc(pluginSchema *plugin.Schema, contentProviderName s
 	return base.ExecuteTemplate(f, "content-provider", templContext)
 }
 
-func renderPublisherDoc(pluginSchema *plugin.Schema, publisherName string, publisher *plugin.Publisher, fp string) error {
-	f, err := os.Create(fp)
+func renderPublisherDoc(
+	pluginSchema *plugin.Schema,
+	publisherName string,
+	publisher *plugin.Publisher,
+	fp string,
+) error {
+	f, err := os.Create(fp) // nolint: gosec
 	if err != nil {
 		return err
 	}
@@ -372,8 +394,13 @@ func renderPublisherDoc(pluginSchema *plugin.Schema, publisherName string, publi
 	return base.ExecuteTemplate(f, "publisher", templContext)
 }
 
-func renderDataSourceDoc(pluginSchema *plugin.Schema, dataSourceName string, dataSource *plugin.DataSource, fp string) error {
-	f, err := os.Create(fp)
+func renderDataSourceDoc(
+	pluginSchema *plugin.Schema,
+	dataSourceName string,
+	dataSource *plugin.DataSource,
+	fp string,
+) error {
+	f, err := os.Create(fp) // nolint: gosec
 	if err != nil {
 		return err
 	}

--- a/tools/docgen/main.go
+++ b/tools/docgen/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"cmp"
 	_ "embed"
 	"encoding/json"
 	"fmt"
@@ -227,7 +228,10 @@ func generateMetadataFile(plugins []*plugin.Schema, outputDir string) {
 		sort.Slice(resources, func(i, j int) bool {
 			a := resources[i]
 			b := resources[j]
-			return a.Name < b.Name && a.Type < b.Type
+			return cmp.Or(
+				cmp.Compare(a.Name, b.Name),
+				cmp.Compare(a.Type, b.Type),
+			) < 0
 		})
 
 		pluginDetails[i] = PluginDetails{
@@ -265,7 +269,6 @@ func generateMetadataFile(plugins []*plugin.Schema, outputDir string) {
 }
 
 func main() {
-
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
 	// parse flags


### PR DESCRIPTION
Partial path in `data` command enables execution of more than a single data block at a time

Possible `path` options:
- `<document-name>.data` -- returns a dict with all data blocks executed
- `<document-name>.data.<data-source>` -- returns a dict with all data blocks of a particular type
- `<document-name>.data.<data-source>.<block-name>` -- returns a dict with a single matching data block